### PR TITLE
Add bnx2/bnx2-rv2p-06-6.0.15.fw firmware blob

### DIFF
--- a/configs/kernelarm.config
+++ b/configs/kernelarm.config
@@ -797,7 +797,7 @@ CONFIG_DEVTMPFS_MOUNT=y
 CONFIG_STANDALONE=y
 CONFIG_PREVENT_FIRMWARE_BUILD=y
 CONFIG_FW_LOADER=y
-CONFIG_EXTRA_FIRMWARE="bnx2x/bnx2x-e1h-7.13.1.0.fw bnx2x/bnx2x-e2-7.13.1.0.fw bnx2/bnx2-mips-09-6.2.1b.fw bnx2/bnx2-mips-06-6.2.3.fw tigon/tg357766.bin rtl_nic/rtl8411-2.fw rtl_nic/rtl8411-1.fw rtl_nic/rtl8402-1.fw rtl_nic/rtl8168h-2.fw rtl_nic/rtl8168h-1.fw rtl_nic/rtl8168g-3.fw rtl_nic/rtl8168g-2.fw rtl_nic/rtl8168g-1.fw rtl_nic/rtl8168f-2.fw rtl_nic/rtl8168f-1.fw rtl_nic/rtl8168e-3.fw rtl_nic/rtl8168e-2.fw rtl_nic/rtl8168e-1.fw rtl_nic/rtl8168d-2.fw rtl_nic/rtl8168d-1.fw rtl_nic/rtl8107e-2.fw rtl_nic/rtl8107e-1.fw rtl_nic/rtl8106e-2.fw rtl_nic/rtl8106e-1.fw rtl_nic/rtl8105e-1.fw bnx2/bnx2-rv2p-09-6.0.17.fw"
+CONFIG_EXTRA_FIRMWARE="bnx2x/bnx2x-e1h-7.13.1.0.fw bnx2x/bnx2x-e2-7.13.1.0.fw bnx2/bnx2-mips-09-6.2.1b.fw bnx2/bnx2-mips-06-6.2.3.fw tigon/tg357766.bin rtl_nic/rtl8411-2.fw rtl_nic/rtl8411-1.fw rtl_nic/rtl8402-1.fw rtl_nic/rtl8168h-2.fw rtl_nic/rtl8168h-1.fw rtl_nic/rtl8168g-3.fw rtl_nic/rtl8168g-2.fw rtl_nic/rtl8168g-1.fw rtl_nic/rtl8168f-2.fw rtl_nic/rtl8168f-1.fw rtl_nic/rtl8168e-3.fw rtl_nic/rtl8168e-2.fw rtl_nic/rtl8168e-1.fw rtl_nic/rtl8168d-2.fw rtl_nic/rtl8168d-1.fw rtl_nic/rtl8107e-2.fw rtl_nic/rtl8107e-1.fw rtl_nic/rtl8106e-2.fw rtl_nic/rtl8106e-1.fw rtl_nic/rtl8105e-1.fw bnx2/bnx2-rv2p-09-6.0.17.fw bnx2/bnx2-rv2p-06-6.0.15.fw"
 CONFIG_EXTRA_FIRMWARE_DIR="linux-firmware"
 # CONFIG_FW_LOADER_USER_HELPER_FALLBACK is not set
 CONFIG_ALLOW_DEV_COREDUMP=y

--- a/configs/kernelarm64.config
+++ b/configs/kernelarm64.config
@@ -754,7 +754,7 @@ CONFIG_DEVTMPFS_MOUNT=y
 CONFIG_STANDALONE=y
 CONFIG_PREVENT_FIRMWARE_BUILD=y
 CONFIG_FW_LOADER=y
-CONFIG_EXTRA_FIRMWARE="bnx2x/bnx2x-e1h-7.13.1.0.fw bnx2x/bnx2x-e2-7.13.1.0.fw bnx2/bnx2-mips-09-6.2.1b.fw bnx2/bnx2-mips-06-6.2.3.fw tigon/tg357766.bin rtl_nic/rtl8411-2.fw rtl_nic/rtl8411-1.fw rtl_nic/rtl8402-1.fw rtl_nic/rtl8168h-2.fw rtl_nic/rtl8168h-1.fw rtl_nic/rtl8168g-3.fw rtl_nic/rtl8168g-2.fw rtl_nic/rtl8168g-1.fw rtl_nic/rtl8168f-2.fw rtl_nic/rtl8168f-1.fw rtl_nic/rtl8168e-3.fw rtl_nic/rtl8168e-2.fw rtl_nic/rtl8168e-1.fw rtl_nic/rtl8168d-2.fw rtl_nic/rtl8168d-1.fw rtl_nic/rtl8107e-2.fw rtl_nic/rtl8107e-1.fw rtl_nic/rtl8106e-2.fw rtl_nic/rtl8106e-1.fw rtl_nic/rtl8105e-1.fw bnx/bnx2-rv2p-09-6.0.17.fw"
+CONFIG_EXTRA_FIRMWARE="bnx2x/bnx2x-e1h-7.13.1.0.fw bnx2x/bnx2x-e2-7.13.1.0.fw bnx2/bnx2-mips-09-6.2.1b.fw bnx2/bnx2-mips-06-6.2.3.fw tigon/tg357766.bin rtl_nic/rtl8411-2.fw rtl_nic/rtl8411-1.fw rtl_nic/rtl8402-1.fw rtl_nic/rtl8168h-2.fw rtl_nic/rtl8168h-1.fw rtl_nic/rtl8168g-3.fw rtl_nic/rtl8168g-2.fw rtl_nic/rtl8168g-1.fw rtl_nic/rtl8168f-2.fw rtl_nic/rtl8168f-1.fw rtl_nic/rtl8168e-3.fw rtl_nic/rtl8168e-2.fw rtl_nic/rtl8168e-1.fw rtl_nic/rtl8168d-2.fw rtl_nic/rtl8168d-1.fw rtl_nic/rtl8107e-2.fw rtl_nic/rtl8107e-1.fw rtl_nic/rtl8106e-2.fw rtl_nic/rtl8106e-1.fw rtl_nic/rtl8105e-1.fw bnx/bnx2-rv2p-09-6.0.17.fw bnx2/bnx2-rv2p-06-6.0.15.fw"
 CONFIG_EXTRA_FIRMWARE_DIR="linux-firmware"
 # CONFIG_FW_LOADER_USER_HELPER_FALLBACK is not set
 CONFIG_ALLOW_DEV_COREDUMP=y

--- a/configs/kernelx64.config
+++ b/configs/kernelx64.config
@@ -826,7 +826,7 @@ CONFIG_DEVTMPFS_MOUNT=y
 CONFIG_STANDALONE=y
 CONFIG_PREVENT_FIRMWARE_BUILD=y
 CONFIG_FW_LOADER=y
-CONFIG_EXTRA_FIRMWARE="bnx2x/bnx2x-e1h-7.13.1.0.fw bnx2x/bnx2x-e2-7.13.1.0.fw bnx2/bnx2-mips-09-6.2.1b.fw bnx2/bnx2-mips-06-6.2.3.fw tigon/tg357766.bin rtl_nic/rtl8411-2.fw rtl_nic/rtl8411-1.fw rtl_nic/rtl8402-1.fw rtl_nic/rtl8168h-2.fw rtl_nic/rtl8168h-1.fw rtl_nic/rtl8168g-3.fw rtl_nic/rtl8168g-2.fw rtl_nic/rtl8168g-1.fw rtl_nic/rtl8168f-2.fw rtl_nic/rtl8168f-1.fw rtl_nic/rtl8168e-3.fw rtl_nic/rtl8168e-2.fw rtl_nic/rtl8168e-1.fw rtl_nic/rtl8168d-2.fw rtl_nic/rtl8168d-1.fw rtl_nic/rtl8107e-2.fw rtl_nic/rtl8107e-1.fw rtl_nic/rtl8106e-2.fw rtl_nic/rtl8106e-1.fw rtl_nic/rtl8105e-1.fw bnx2/bnx2-rv2p-09-6.0.17.fw"
+CONFIG_EXTRA_FIRMWARE="bnx2x/bnx2x-e1h-7.13.1.0.fw bnx2x/bnx2x-e2-7.13.1.0.fw bnx2/bnx2-mips-09-6.2.1b.fw bnx2/bnx2-mips-06-6.2.3.fw tigon/tg357766.bin rtl_nic/rtl8411-2.fw rtl_nic/rtl8411-1.fw rtl_nic/rtl8402-1.fw rtl_nic/rtl8168h-2.fw rtl_nic/rtl8168h-1.fw rtl_nic/rtl8168g-3.fw rtl_nic/rtl8168g-2.fw rtl_nic/rtl8168g-1.fw rtl_nic/rtl8168f-2.fw rtl_nic/rtl8168f-1.fw rtl_nic/rtl8168e-3.fw rtl_nic/rtl8168e-2.fw rtl_nic/rtl8168e-1.fw rtl_nic/rtl8168d-2.fw rtl_nic/rtl8168d-1.fw rtl_nic/rtl8107e-2.fw rtl_nic/rtl8107e-1.fw rtl_nic/rtl8106e-2.fw rtl_nic/rtl8106e-1.fw rtl_nic/rtl8105e-1.fw bnx2/bnx2-rv2p-09-6.0.17.fw bnx2/bnx2-rv2p-06-6.0.15.fw"
 CONFIG_EXTRA_FIRMWARE_DIR="linux-firmware"
 CONFIG_FW_LOADER_USER_HELPER=y
 # CONFIG_FW_LOADER_USER_HELPER_FALLBACK is not set

--- a/configs/kernelx86.config
+++ b/configs/kernelx86.config
@@ -841,7 +841,7 @@ CONFIG_DEVTMPFS_MOUNT=y
 CONFIG_STANDALONE=y
 CONFIG_PREVENT_FIRMWARE_BUILD=y
 CONFIG_FW_LOADER=y
-CONFIG_EXTRA_FIRMWARE="bnx2x/bnx2x-e1h-7.13.1.0.fw bnx2x/bnx2x-e2-7.13.1.0.fw bnx2/bnx2-mips-09-6.2.1b.fw bnx2/bnx2-mips-06-6.2.3.fw tigon/tg357766.bin rtl_nic/rtl8411-2.fw rtl_nic/rtl8411-1.fw rtl_nic/rtl8402-1.fw rtl_nic/rtl8168h-2.fw rtl_nic/rtl8168h-1.fw rtl_nic/rtl8168g-3.fw rtl_nic/rtl8168g-2.fw rtl_nic/rtl8168g-1.fw rtl_nic/rtl8168f-2.fw rtl_nic/rtl8168f-1.fw rtl_nic/rtl8168e-3.fw rtl_nic/rtl8168e-2.fw rtl_nic/rtl8168e-1.fw rtl_nic/rtl8168d-2.fw rtl_nic/rtl8168d-1.fw rtl_nic/rtl8107e-2.fw rtl_nic/rtl8107e-1.fw rtl_nic/rtl8106e-2.fw rtl_nic/rtl8106e-1.fw rtl_nic/rtl8105e-1.fw bnx2/bnx2-rv2p-09-6.0.17.fw"
+CONFIG_EXTRA_FIRMWARE="bnx2x/bnx2x-e1h-7.13.1.0.fw bnx2x/bnx2x-e2-7.13.1.0.fw bnx2/bnx2-mips-09-6.2.1b.fw bnx2/bnx2-mips-06-6.2.3.fw tigon/tg357766.bin rtl_nic/rtl8411-2.fw rtl_nic/rtl8411-1.fw rtl_nic/rtl8402-1.fw rtl_nic/rtl8168h-2.fw rtl_nic/rtl8168h-1.fw rtl_nic/rtl8168g-3.fw rtl_nic/rtl8168g-2.fw rtl_nic/rtl8168g-1.fw rtl_nic/rtl8168f-2.fw rtl_nic/rtl8168f-1.fw rtl_nic/rtl8168e-3.fw rtl_nic/rtl8168e-2.fw rtl_nic/rtl8168e-1.fw rtl_nic/rtl8168d-2.fw rtl_nic/rtl8168d-1.fw rtl_nic/rtl8107e-2.fw rtl_nic/rtl8107e-1.fw rtl_nic/rtl8106e-2.fw rtl_nic/rtl8106e-1.fw rtl_nic/rtl8105e-1.fw bnx2/bnx2-rv2p-09-6.0.17.fw bnx2/bnx2-rv2p-06-6.0.15.fw"
 CONFIG_EXTRA_FIRMWARE_DIR="linux-firmware"
 CONFIG_FW_LOADER_USER_HELPER=y
 # CONFIG_FW_LOADER_USER_HELPER_FALLBACK is not set


### PR DESCRIPTION
Would you mind adding this and building fresh kernel images? Has been [requested in the forums](https://forums.fogproject.org/topic/12454/dell-pe1950-gets-error-can-t-load-firmware-file-bnx2-bnx2-rv2p-06-6-0-15-fw).