### PR TITLE
Change label test for reserved partition

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -490,7 +490,7 @@ shrinkPartition() {
                 debugPause
                 return
             fi
-            if [[ $label =~ [Rr][Ee][Ss][Ee][Rr][Vv][Ee][Dd] || $label =~ [Rr][Éé][Ss][Éé][Rr][Vv][Éé] ]]; then
+            if [[ $label =~ [Rr][EeÉé][Ss][Ee][Rr][Vv][EeÉé][Dd]? ]]; then
                 echo "$(cat "$imagePath/d1.fixed_size_partitions" | tr -d \\0):${part_number}" > "$imagePath/d1.fixed_size_partitions"
                 echo " * Not shrinking ($part) reserved partitions"
                 debugPause


### PR DESCRIPTION
It's been a long standing problem that the test fails for the label of the System Reserved partition for certain languages. 

The test has been updated to work across more languages now. It's slightly less precise, but more neat and should now work for English, French and Dutch (and possibly others that I didn't think about).

The original test had an é in the middle which never matched and thus French users had resize problems all the time. This could of course simply be edited, but I wanted to push this new regex instead as it also works for Dutch.