### PR TITLE
Switch label detection for non-resizable NTFS partitions to partition…

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.upload
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.upload
@@ -57,6 +57,7 @@ beginUpload() {
             dots "Getting Windows/Linux Partition Count"
             countPartTypes "$hd" "ntfs" "ntfscnt"
             countPartTypes "$hd" "extfs" "extfscnt"
+            countPartTypes "$hd" "*" "partscnt"
             if [[ $ntfscnt -eq 0 && $extfscnt -eq 0 ]]; then
                 echo "Failed"
                 debugPause
@@ -68,6 +69,8 @@ beginUpload() {
             debugPause
             echo " * EXTFS Partition count of: $extfscnt"
             debugPause
+            echo " * Total Partition count of: $partscnt"
+            debugPause
             case $osid in
                 [4-7]|9|50|51)
                     echo " * Setting up any additional fixed parts"
@@ -75,7 +78,7 @@ beginUpload() {
                     for part in $parts; do
                         getPartitionNumber "$part"
                         fsTypeSetting "$part"
-                        getPartitionLabel "$part"
+                        #getPartitionLabel "$part"
                         [[ $fstype != ntfs ]] && continue
                         dots "Mounting partition ($part)"
                         if [[ ! -d /bcdstore ]]; then
@@ -103,9 +106,11 @@ beginUpload() {
                                 ;;
                         esac
                         umount /bcdstore >/dev/null 2>&1
-                        if [[ $label =~ [Rr][EeÉé][Ss][Ee][Rr][Vv][EeÉé][Dd]? || $label =~ [Rr][Ee][Cc][Oo][Vv][Ee][Rr][Yy] ]]; then
-                                echo " * New fixed partition for ($part) added."
-                                fixed_size_partitions="$fixed_size_partitions:$part_number"
+                        if [[ $partscnt -gt 1 ]]; then			
+                                if [[ $(parted -l "$hd" | grep boot | awk '{print $1}') -eq $part_number || $(parted -l "$hd" | grep msftres | awk '{print $1}') -eq $part_number || $(parted -l "$hd" | grep hidden | awk '{print $1}') -eq $part_number ]]; then
+                                        echo " * New fixed partition for ($part) added."
+                                        fixed_size_partitions="$fixed_size_partitions:$part_number"
+                                fi
                         fi
                     done
                     ;;

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.upload
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.upload
@@ -78,7 +78,6 @@ beginUpload() {
                     for part in $parts; do
                         getPartitionNumber "$part"
                         fsTypeSetting "$part"
-                        #getPartitionLabel "$part"
                         [[ $fstype != ntfs ]] && continue
                         dots "Mounting partition ($part)"
                         if [[ ! -d /bcdstore ]]; then

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -483,14 +483,13 @@ shrinkPartition() {
     local part_block_size=0
     case $fstype in
         ntfs)
-            local label=$(getPartitionLabel "$part")
-            if [[ $label =~ [Rr][Ee][Cc][Oo][Vv][Ee][Rr][Yy] ]]; then
+            if [[ $(parted -l "$hd" | grep msftres | awk '{print $1}') -eq $part_number ]]; then
                 echo "$(cat "$imagePath/d1.fixed_size_partitions" | tr -d \\0):${part_number}" > "$imagePath/d1.fixed_size_partitions"
                 echo " * Not shrinking ($part) recovery partition"
                 debugPause
                 return
             fi
-            if [[ $label =~ [Rr][EeÉé][Ss][Ee][Rr][Vv][EeÉé][Dd]? ]]; then
+            if [[ $(parted -l "$hd" | grep boot | awk '{print $1}') -eq $part_number || $(parted -l "$hd" | grep hidden | awk '{print $1}') -eq $part_number ]]; then
                 echo "$(cat "$imagePath/d1.fixed_size_partitions" | tr -d \\0):${part_number}" > "$imagePath/d1.fixed_size_partitions"
                 echo " * Not shrinking ($part) reserved partitions"
                 debugPause

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/partition-funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/partition-funcs.sh
@@ -525,11 +525,6 @@ processSfdisk() {
     # process with external awk script
     [[ -r $data ]] && /usr/share/fog/lib/procsfdisk.awk $awkArgs $data $orig || /usr/share/fog/lib/procsfdisk.awk $awkArgs $orig
 }
-getPartitionLabel() {
-    local part="$1"
-    [[ -z $part ]] && handleError "No part passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    label=$(blkid -po udev $part | awk -F= /FS_LABEL=/'{print $2}')
-}
 #
 # GPT Functions below
 #


### PR DESCRIPTION
… flag based detection

Also added a total partition count display as I figure that will be useful if something goes wrong anyway, just some quick info that I needed anyway.

Tested on 

Windows 7 Professional 64 bit French install
                 Windows 10 Home GPT install  (based on latest released Microsoft ISO (november 2018?))
                 Windows 10 Home MBR install (based on latest released Microsoft ISO (november 2018?))

Should hopefully address https://github.com/FOGProject/fos/issues/18