### PR TITLE
Rely on bin/fog.upload logic for fixed parts

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -438,6 +438,7 @@ shrinkPartition() {
     local is_fixed=$(echo $fixed | awk "/(^$part_number:|:$part_number:|:$part_number$|^$part_number$)/{print 1}")
     if [[ $is_fixed -eq 1 ]]; then
         echo " * Not shrinking ($part) fixed size"
+        echo "$(cat "$imagePath/d1.fixed_size_partitions" | tr -d \\0):${part_number}" > "$imagePath/d1.fixed_size_partitions"
         debugPause
         return
     fi
@@ -459,12 +460,6 @@ shrinkPartition() {
     local part_block_size=0
     case $fstype in
         ntfs)
-            if [[ $is_fixed -eq 1 ]]; then
-                echo "$(cat "$imagePath/d1.fixed_size_partitions" | tr -d \\0):${part_number}" > "$imagePath/d1.fixed_size_partitions"
-                echo " * Not shrinking ($part) recovery/reserved partition"
-                debugPause
-                return
-            fi
             ntfsresize -fivP $part >/tmp/tmpoutput.txt 2>&1
             if [[ ! $? -eq 0 ]]; then
                 echo " * Not shrinking ($part) trying fixed size"

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -459,15 +459,9 @@ shrinkPartition() {
     local part_block_size=0
     case $fstype in
         ntfs)
-            if [[ $(parted -l "$hd" | grep msftres | awk '{print $1}') -eq $part_number ]]; then
+            if [[ $is_fixed -eq 1 ]]; then
                 echo "$(cat "$imagePath/d1.fixed_size_partitions" | tr -d \\0):${part_number}" > "$imagePath/d1.fixed_size_partitions"
-                echo " * Not shrinking ($part) recovery partition"
-                debugPause
-                return
-            fi
-            if [[ $(parted -l "$hd" | grep boot | awk '{print $1}') -eq $part_number || $(parted -l "$hd" | grep hidden | awk '{print $1}') -eq $part_number ]]; then
-                echo "$(cat "$imagePath/d1.fixed_size_partitions" | tr -d \\0):${part_number}" > "$imagePath/d1.fixed_size_partitions"
-                echo " * Not shrinking ($part) reserved partitions"
+                echo " * Not shrinking ($part) recovery/reserved partition"
                 debugPause
                 return
             fi


### PR DESCRIPTION
In order to avoid having to maintain essentially the same code twice in different locations, rely on the code in bin/fog.upload and simply read out and check against the value (like it already does earlier in the file anyway!)