### PR TITLE
Fix invalid tests + minor cleanup

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/partition-funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/partition-funcs.sh
@@ -14,7 +14,13 @@ saveSfdiskPartitions() {
     local disk="$1"
     local file="$2"
     [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $file ]] && handleError "No file to save to (${FUNCNAME[0]})\n   Args Passed: $*"
+    if [[ ! -f $file ]] then;
+        handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    else
+        if [[ ! -s $file ]] then;
+            handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+        fi
+    fi
     sfdisk -d $disk 2>/dev/null > $file
     [[ ! $? -eq 0 ]] && majorDebugEcho "sfdisk failed in (${FUNCNAME[0]})"
 }
@@ -28,7 +34,13 @@ restoreUUIDInformation() {
     local disk_number="$3"
     local imagePath="$4"
     [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $file ]] && handleError "No file to load from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    if [[ ! -f $file ]] then;
+        handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    else
+        if [[ ! -s $file ]] then;
+            handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+        fi
+    fi
     [[ -z $disk_number ]] && handleError "No disk number passed (${FUNCNAME[0]})\n   Args Passed: $*"
     [[ -z $imagePath ]] && handleError "No image path passed (${FUNCNAME[0]})\n   Args Passed: $*"
     local diskuuid=""
@@ -79,7 +91,13 @@ applySfdiskPartitions() {
     local disk="$1"
     local file="$2"
     [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $file ]] && handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    if [[ ! -f $file ]] then;
+        handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    else
+        if [[ ! -s $file ]] then;
+            handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+        fi
+    fi
     sfdisk $disk < $file >/dev/null 2>&1
     [[ ! $? -eq 0 ]] && majorDebugEcho "sfdisk failed in (${FUNCNAME[0]})"
 }
@@ -89,7 +107,13 @@ restoreSfdiskPartitions() {
     local disk="$1"
     local file="$2"
     [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $file ]] && handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    if [[ ! -f $file ]] then;
+        handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    else
+        if [[ ! -s $file ]] then;
+            handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+        fi
+    fi
     applySfdiskPartitions "$disk" "$file"
     fdisk $disk < /usr/share/fog/lib/EOFRESTOREPART >/dev/null 2>&1
     [[ ! $? -eq 0 ]] && majorDebugEcho "fdisk failed in (${FUNCNAME[0]})"
@@ -121,7 +145,13 @@ saveEBR() {
     local part="$1"
     local file="$2"
     [[ -z $part ]] && handleError "No partition passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $file ]] && handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+        if [[ ! -f $file ]] then;
+        handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    else
+        if [[ ! -s $file ]] then;
+            handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+        fi
+    fi
     local disk=""
     getDiskFromPartition "$part"
     local table_type=""
@@ -171,7 +201,13 @@ restoreEBR() {
     local part="$1"
     local file="$2"
     [[ -z $part ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $file ]] && handleError "No file to restore from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    if [[ ! -f $file ]] then;
+        handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    else
+        if [[ ! -s $file ]] then;
+            handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+        fi
+    fi
     local disk=""
     local table_type=""
     getDiskFromPartition "$part"
@@ -237,7 +273,13 @@ saveSwapUUID() {
     local file="$1"
     local part="$2"
     [[ -z $part ]] && handleError "No partition passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $file ]] && handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+        if [[ ! -f $file ]] then;
+        handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    else
+        if [[ ! -s $file ]] then;
+            handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+        fi
+    fi
     local is_swap=0
     partitionIsSwap "$part"
     [[ $is_swap -eq 0 ]] && return
@@ -318,7 +360,13 @@ makeSwapSystem() {
     local file="$1"
     local part="$2"
     [[ -z $part ]] && handleError "No partition passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $file ]] && handleError "No file passed (${FUNCNAME[0]})\n   Args Passed: $*"
+        if [[ ! -f $file ]] then;
+        handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    else
+        if [[ ! -s $file ]] then;
+            handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+        fi
+    fi
     local option=""
     local disk=""
     getDiskFromPartition "$part"
@@ -394,7 +442,13 @@ fillSfdiskWithPartitions() {
     local fixed="$4"
     local orig="$5"
     [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $file ]] && handleError "No file to use passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    if [[ ! -f $file ]] then;
+        handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    else
+        if [[ ! -s $file ]] then;
+            handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
+        fi
+    fi
     rm -rf /tmp/sfdisk{1,2}.*
     local disk_size=$(blockdev --getsz $disk)
     #local tmp_file1="/tmp/sfdisk1.$$"

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/partition-funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/partition-funcs.sh
@@ -14,10 +14,10 @@ saveSfdiskPartitions() {
     local disk="$1"
     local file="$2"
     [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    if [[ ! -f $file ]] then;
+    if [[ ! -f $file ]]; then
         handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
     else
-        if [[ ! -s $file ]] then;
+        if [[ ! -s $file ]]; then
             handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
         fi
     fi
@@ -34,10 +34,10 @@ restoreUUIDInformation() {
     local disk_number="$3"
     local imagePath="$4"
     [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    if [[ ! -f $file ]] then;
+    if [[ ! -f $file ]]; then
         handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
     else
-        if [[ ! -s $file ]] then;
+        if [[ ! -s $file ]]; then
             handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
         fi
     fi
@@ -68,7 +68,7 @@ restoreUUIDInformation() {
         dots "Partition type being set to"
         echo $parttype
         debugPause
-        if [[ -n $parttype ]] then;
+        if [[ -n $parttype ]]; then
             sgdisk -t $parttype $disk >/dev/null 2>&1 
         else 
             true
@@ -77,7 +77,7 @@ restoreUUIDInformation() {
         dots "Partition uuid being set to"
         echo $partuuid
         debugPause
-        if [[ -n $partuuid ]] then;
+        if [[ -n $partuuid ]]; then
             sgdisk -u $partuuid $disk >/dev/null 2>&1 
         else 
             true
@@ -91,10 +91,10 @@ applySfdiskPartitions() {
     local disk="$1"
     local file="$2"
     [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    if [[ ! -f $file ]] then;
+    if [[ ! -f $file ]]; then
         handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
     else
-        if [[ ! -s $file ]] then;
+        if [[ ! -s $file ]]; then
             handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
         fi
     fi
@@ -107,10 +107,10 @@ restoreSfdiskPartitions() {
     local disk="$1"
     local file="$2"
     [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    if [[ ! -f $file ]] then;
+    if [[ ! -f $file ]]; then
         handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
     else
-        if [[ ! -s $file ]] then;
+        if [[ ! -s $file ]]; then
             handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
         fi
     fi
@@ -145,10 +145,10 @@ saveEBR() {
     local part="$1"
     local file="$2"
     [[ -z $part ]] && handleError "No partition passed (${FUNCNAME[0]})\n   Args Passed: $*"
-        if [[ ! -f $file ]] then;
+    if [[ ! -f $file ]]; then
         handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
     else
-        if [[ ! -s $file ]] then;
+        if [[ ! -s $file ]]; then
             handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
         fi
     fi
@@ -201,10 +201,10 @@ restoreEBR() {
     local part="$1"
     local file="$2"
     [[ -z $part ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    if [[ ! -f $file ]] then;
+    if [[ ! -f $file ]]; then
         handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
     else
-        if [[ ! -s $file ]] then;
+        if [[ ! -s $file ]]; then
             handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
         fi
     fi
@@ -273,10 +273,10 @@ saveSwapUUID() {
     local file="$1"
     local part="$2"
     [[ -z $part ]] && handleError "No partition passed (${FUNCNAME[0]})\n   Args Passed: $*"
-        if [[ ! -f $file ]] then;
+    if [[ ! -f $file ]]; then
         handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
     else
-        if [[ ! -s $file ]] then;
+        if [[ ! -s $file ]]; then
             handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
         fi
     fi
@@ -360,10 +360,10 @@ makeSwapSystem() {
     local file="$1"
     local part="$2"
     [[ -z $part ]] && handleError "No partition passed (${FUNCNAME[0]})\n   Args Passed: $*"
-        if [[ ! -f $file ]] then;
+    if [[ ! -f $file ]]; then
         handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
     else
-        if [[ ! -s $file ]] then;
+        if [[ ! -s $file ]]; then
             handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
         fi
     fi
@@ -442,10 +442,10 @@ fillSfdiskWithPartitions() {
     local fixed="$4"
     local orig="$5"
     [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    if [[ ! -f $file ]] then;
+    if [[ ! -f $file ]]; then
         handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
     else
-        if [[ ! -s $file ]] then;
+        if [[ ! -s $file ]]; then
             handleError "File received was empty from passed (${FUNCNAME[0]})\n   Args Passed: $*"
         fi
     fi
@@ -549,7 +549,7 @@ processSfdisk() {
     awkArgs="$awkArgs -v diskSize=$disk_size"
     [[ -n $fixed ]] && awkArgs="$awkArgs -v fixedList=$fixed"
     # process with external awk script
-    if [[ -r $data ]] then;
+    if [[ -r $data ]]; then
         /usr/share/fog/lib/procsfdisk.awk $awkArgs $data $orig 
     else 
         /usr/share/fog/lib/procsfdisk.awk $awkArgs $orig


### PR DESCRIPTION
Removed unused variable in restoreUUIDInformation

Changed invalid tests in restoreUUIDInformation (would always return true if initial test succeeded even if sgdisk failed) 
You can test this locally like so: `[[ 1 -eq 1 ]] && false || echo 0` (or even `true && false || echo 0` will echo 0

Replaced egrep with grep -E since egrep is deprecated

Replaced != with -ne since $part_number is expected to be a number in restoreAllEbrs

Improved readability of test in processSfDisk

Changed file tests from simple string test, to checking if file exists and if it is empty or not.