### PR TITLE
Use larger block size for normal wipe

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.wipe
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.wipe
@@ -20,7 +20,7 @@ case $wipemode in
         ;;
     normal)
         echo " Writing zeros to $hd"
-        dd if=/dev/zero of="$hd" >/dev/null 2>&1
+        dd if=/dev/zero of="$hd" bs=512k >/dev/null 2>&1
         echo -e "\n Wiping complete.\n"
         ;;
     fast|fastwipe)


### PR DESCRIPTION
With `dd` using the default block size of 512 bytes, the normal wipe can take as long as a full wipe. 
A block size of 512k (kibibytes) should work with any disk and speeds up the wiping considerably.
See https://github.com/FOGProject/fos/issues/38