### PR TITLE
Fixing a typo in the calculate_float function and adding a couple of messages to the resizing functions

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -260,6 +260,7 @@ expandPartition() {
             ;;
         btrfs)
             # Based on info from @mstabrin on forums.fogproject.org
+            dots "Resizing $fstype volume ($part)"
             if [[ ! -d /tmp/btrfs ]]; then
                 mkdir /tmp/btrfs >>/tmp/btfrslog.txt 2>&1
                 if [[ $? -gt 0 ]]; then
@@ -610,7 +611,7 @@ shrinkPartition() {
             resetFlag "$part"
             ;;
         extfs)
-            dots "Checking $fstype volume ($part)"
+            dots "Checking $fstype volume ($part) before shrinking"
             e2fsck -fp $part >/tmp/e2fsck.txt 2>&1
             case $? in
                 0)
@@ -646,6 +647,7 @@ shrinkPartition() {
             resizePartition "$part" "$sizeextresize" "$imagePath"
             echo "Done"
             debugPause
+            dots "Checking $fstype volume ($part) after shrinking"
             e2fsck -fp $part >/tmp/e2fsck.txt 2>&1
             case $? in
                 0)
@@ -665,6 +667,7 @@ shrinkPartition() {
         btrfs)
             # Based on info from @mstabrin on forums.fogproject.org
             # https://forums.fogproject.org/topic/15159/btrfs-postdownloadscript/3
+            dots "Shrinking $part partition"
             if [[ ! -d /tmp/btrfs ]]; then
                 mkdir /tmp/btrfs >>/tmp/btfrslog.txt 2>&1
                 if [[ $? -gt 0 ]]; then
@@ -2516,5 +2519,5 @@ calculate() {
 }
 # Calculates information and returns full float
 calculate_float() {
-    echo $(awk 'BEGIN{printf "%f\n"}, '$*'}');
+    echo $(awk 'BEGIN{printf "%f\n", '$*'}');
 }


### PR DESCRIPTION
I fixed a typo in the calculate_float function that was causing the BTRFS expandable image capture to not work correctly and throw errors. In addition, I added messages about expanding and shrinking BTRFS partitions, and modified the messages about checking EXTFS partitions, as the script checks the partition before and after shrinking, and the message only displays before shrinking.