### PR TITLE
Change mount commands to fix exFAT-FS errors

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -268,7 +268,7 @@ expandPartition() {
                     handleError "Could not create /tmp/btrfs (${FUNCNAME[0]})\n   Info: $(cat /tmp/btrfslog.txt)\n   Args Passed: $*"
                 fi
             fi
-            mount $part /tmp/btrfs >>/tmp/btrfslog.txt 2>&1
+            mount -t btrfs $part /tmp/btrfs >>/tmp/btrfslog.txt 2>&1
             if [[ $? -gt 0 ]]; then
                 echo "Failed"
                 debugPause
@@ -673,7 +673,7 @@ shrinkPartition() {
                     handleError "Could not create /tmp/btrfs (${FUNCNAME[0]})\n   Info: $(cat /tmp/btrfslog.txt)\n   Args Passed: $*"
                 fi
             fi
-            mount $part /tmp/btrfs >>/tmp/btrfslog.txt 2>&1
+            mount -t btrfs $part /tmp/btrfs >>/tmp/btrfslog.txt 2>&1
             if [[ $? -gt 0 ]]; then
                 echo "Failed"
                 debugPause


### PR DESCRIPTION
I added the "-t btrfs" parameter to the mount command when mounting a BTRFS partition to avoid showing exFAT-FS-related errors.

Before:
![EXFAT_ERRORS](https://user-images.githubusercontent.com/39170443/193417525-7969875d-be90-407a-b4be-11be42de8a9f.png)

After:
![EXFATERROR_GONE](https://user-images.githubusercontent.com/39170443/193417526-ce16b9b8-0809-4dcb-8fbe-9d1d1afdc114.png)
