### PR TITLE
Don't wait indefinitly on network errors

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/etc/init.d/S40network
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/etc/init.d/S40network
@@ -59,5 +59,5 @@ fi
 echo "Please check your network setup and try again!"
 [[ -z $isdebug ]] && sleep 60 && reboot
 echo "Press enter to continue"
-read
+read -t 60
 exit 1


### PR DESCRIPTION
If we have problems with DHCP or we can't reach the FOG web server, then the network script will wait for user input indefinitely. In unattended scenarios (cron induced capture) this will lock the system until the user notice the problem.

In my case, the problem is often resolved by a simple reboot (seems like a spanning tree problem, but it is strange that a simple reboot fixes the problem).

I undestand that user should have the ability to analyze the problem by reading on screen log, but there is no need to wait for input indefinitely. Instead, we can use `read -t 60` or less, as we will hit another 60 seconds timeout in the next script