### PR TITLE
Add XFS partition imaging support.

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.upload
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.upload
@@ -46,7 +46,7 @@ beginUpload() {
                 fsTypeSetting "$part"
                 getPartitionNumber "$part"
                 case $fstype in
-                    ntfs|extfs|btrfs|f2fs)
+                    ntfs|extfs|btrfs|f2fs|xfs)
                         continue
                         ;;
                     *)
@@ -61,8 +61,9 @@ beginUpload() {
             countPartTypes "$hd" "extfs" "extfscnt"
             countPartTypes "$hd" "btrfs" "btrfscnt"
             countPartTypes "$hd" "f2fs" "f2fscnt"
+            countPartTypes "$hd" "xfs" "xfscnt"
             countPartTypes "$hd" "*" "partscnt"
-            if [[ $ntfscnt -eq 0 && $extfscnt -eq 0 && $btrfscnt -eq 0 && $f2fscnt -eq 0 ]]; then
+            if [[ $ntfscnt -eq 0 && $extfscnt -eq 0 && $btrfscnt -eq 0 && $f2fscnt -eq 0 && $xfscnt -eq 0 ]]; then
                 echo "Failed"
                 debugPause
                 handleError "No resizable partitions found ($0)\n   Args Passed: $*"
@@ -76,6 +77,8 @@ beginUpload() {
             echo " * BTRFS Partition count of: $btrfscnt"
             debugPause
             echo " * F2FS Partition count of: $f2fscnt"
+            debugPause
+            echo " * XFS Partition count of: $xfscnt"
             debugPause
             echo " * Total Partition count of: $partscnt"
             debugPause

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -301,6 +301,53 @@ expandPartition() {
                 echo "Done"
             fi
             ;;
+        xfs)
+            if [[ $type == "down" ]]; then
+                dots "Attempting to resize $fstype volume ($part)"
+
+                # XFS partitions can only be expanded when there is free space after that partition.
+                # Retrieving the partition number of a XFS partition that hass free space after it.
+                local xfsPartitionNumberThatCanBeExpanded=$(parted -s -a opt $disk "print free" | grep -i "free space" -B 1 | grep -i "xfs" | cut -d ' ' -f2)
+                local currentPartitionNumber=$(cat /proc/partitions | grep "${part//\/dev\/}" | sed -n '{s/  */ /gp}' | cut -d ' ' -f3)
+                if [[ $xfsPartitionNumberThatCanBeExpanded == $currentPartitionNumber ]]; then
+                    parted -s -a opt $disk "resizepart $xfsPartitionNumberThatCanBeExpanded 100%" >>/tmp/xfslog.txt 2>&1
+                    if [[ $? -gt 0 ]]; then
+                        echo "Failed"
+                        debugPause
+                        handleError "Could not resize partition $part (${FUNCNAME[0]})\n   Info: $(cat /tmp/xfslog.txt)\n   Args Passed: $*"
+                    fi
+                    if [[ ! -d /tmp/xfs ]]; then
+                        mkdir /tmp/xfs >>/tmp/xfslog.txt 2>&1
+                        if [[ $? -gt 0 ]]; then
+                            echo "Failed"
+                            debugPause
+                            handleError "Could not create /tmp/xfs (${FUNCNAME[0]})\n   Info: $(cat /tmp/xfslog.txt)\n   Args Passed: $*"
+                        fi
+                    fi
+                    mount -t xfs $part /tmp/xfs >>/tmp/xfslog.txt 2>&1
+                    if [[ $? -gt 0 ]]; then
+                        echo "Failed"
+                        debugPause
+                        handleError "Could not mount $part to /tmp/xfs (${FUNCNAME[0]})\n   Info: $(cat /tmp/xfslog.txt)\n   Args Passed: $*"
+                    fi
+                    xfs_growfs $part >>/tmp/xfslog.txt 2>&1
+                    if [[ $? -gt 0 ]]; then
+                        echo "Failed"
+                        debugPause
+                        handleError "Could not grow XFS partition $part (${FUNCNAME[0]})\n   Info: $(cat /tmp/xfslog.txt)\n   Args Passed: $*"
+                    fi
+                    umount /tmp/xfs >>/tmp/xfslog.txt 2>&1
+                    if [[ $? -gt 0 ]]; then
+                        echo Failed
+                        debugPause
+                        handleError "Could not unmount $part from /tmp/xfs (${FUNCNAME[0]})\n   Info: $(cat /tmp/xfslog.txt)\n   Args Passed: $*"
+                    fi
+                    echo "Done"
+                else
+                    echo "Failed, XFS partition cannot be expanded"
+                fi
+            fi
+            ;;
         *)
             echo " * Not expanding ($part -- $fstype)"
             debugPause
@@ -723,6 +770,9 @@ shrinkPartition() {
             ;;
         f2fs)
             echo " * Cannot shrink F2FS partitions"
+            ;;
+        xfs)
+            echo " * Cannot shrink XFS partitions"
             ;;
         *)
             echo " * Not shrinking ($part $fstype)"


### PR DESCRIPTION
I have tested these changes with CentOS Stream 9 and Fedora 37 with a single XFS partition and 2 XFS partitions on both distros.
**XFS partitions can only be expanded when there is free space after that partition.**

Resolves #66