### PR TITLE
Fixes to GitHub Actions

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -35,7 +35,7 @@ defaults:
 
 jobs:
   build_kernel_arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
@@ -61,7 +61,7 @@ jobs:
           retention-days: 1
 
   build_kernel_x86:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
@@ -87,7 +87,7 @@ jobs:
           retention-days: 1
 
   build_kernel_x64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
@@ -113,7 +113,7 @@ jobs:
           retention-days: 1
 
   build_initrd_arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
@@ -146,7 +146,7 @@ jobs:
           retention-days: 30
 
   build_initrd_x86:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
@@ -179,7 +179,7 @@ jobs:
           retention-days: 30
 
   build_initrd_x64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
@@ -222,7 +222,7 @@ jobs:
         build_initrd_x64,
       ]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Download distribution files

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -242,7 +242,7 @@ jobs:
 
       - name: Set release name variable
         run: |
-          echo "RELEASE_NAME=\"Latest from $(date '+%Y-%m-%d')\"" >> $GITHUB_ENV
+          echo "RELEASE_NAME=Latest from $(date '+%Y-%m-%d')" >> $GITHUB_ENV
           
       - name: Set tag name variable
         run: |
@@ -261,7 +261,7 @@ jobs:
           is_official="${{ inputs.is_official_release }}"
           fog_version="${{ inputs.official_fog_version }}"
           if [[ ${{ inputs.is_official_release }} == "true" ]]; then
-            echo "RELEASE_NAME=\"FOG $fog_version kernels and inits\"" >> $GITHUB_ENV
+            echo "RELEASE_NAME=FOG $fog_version kernels and inits" >> $GITHUB_ENV
             echo "TAG_NAME=$fog_version" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -22,12 +22,16 @@ jobs:
     runs-on: ubuntu-22.04
     
     steps:
-      - name: Make sure the official FOG version input box was entered if the is official checkbox was selected
+      - name: Make sure that the input text field is filled in if the input checkbox is selected and vice versa
         run: |
           is_official="${{ inputs.is_official_release }}"
           fog_version="${{ inputs.official_fog_version }}"
-          if [[ $is_official == "true" && $fog_version == "" ]]; then
-            echo "Official FOG Version was not entered!"
+          if [[ "$is_official" == "true" && "$fog_version" == "" ]]; then
+            echo "Official FOG Version was not entered, but Official Release checkbox was selected!"
+            exit 1
+          fi
+          if [[ "$is_official" == "false" && "$fog_version" != "" ]]; then
+            echo "Official Release checkbox was not selected, but Official Release FOG Version was entered!"
             exit 1
           fi
 

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -3,30 +3,14 @@ name: Create Release
 on:
   workflow_dispatch:
     inputs:
-      release_name:
-        type: string
-        description: "Release Name"
-        required: true
-      tag_name:
-        type: string
-        description: "Tag Name"
-        required: true
-      is_prerelease:
+      is_official_release:
         type: boolean
         default: false
-        description: "Pre-release?"
-        required: true
-      linux_kernel_version:
+        description: "Official Release?"
+        required: false
+      official_fog_version:
         type: string
-        description: "Linux kernel version"
-        required: true
-      buildroot_version:
-        type: string
-        description: "Buildroot version"
-        required: true
-      extra_description:
-        type: string
-        description: "Description"
+        description: "Official Release FOG Version"
         required: false
 
 defaults:
@@ -225,8 +209,36 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Download distribution files
         uses: actions/download-artifact@v3
+
+      - name: Set release name variable
+        run: |
+          echo "RELEASE_NAME=\"Latest from $(date '+%Y-%d-%m')\"" >> $GITHUB_ENV
+          
+      - name: Set tag name variable
+        run: |
+          echo "TAG_NAME=$(date '+%Y%m%d')" >> $GITHUB_ENV
+
+      - name: Get Linux Kernel version from build.sh
+        run: |
+          echo "LINUX_KERNEL_VER=$(cat build.sh | sed -n -e 's/^.*KERNEL_VERSION=//p' | cut -d\' -f 2)" >> $GITHUB_ENV
+
+      - name: Get Buildroot version from build.sh
+        run: |
+          echo "BUILDROOT_VER=$(cat build.sh | sed -n -e 's/^.*BUILDROOT_VERSION=//p' | cut -d\' -f 2)" >> $GITHUB_ENV
+
+      - name: Official FOG release
+        run: |
+          is_official="${{ inputs.is_official_release }}"
+          fog_version="${{ inputs.official_fog_version }}"
+          if [[ ${{ inputs.is_official_release }} == "true" ]]; then
+            echo "RELEASE_NAME=\"FOG $fog_version kernels and inits\"" >> $GITHUB_ENV
+            echo "TAG_NAME=$fog_version" >> $GITHUB_ENV
+          fi
 
       - name: Run sha256 checksum on all files
         run: |
@@ -237,13 +249,11 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
-          name: ${{ github.event.inputs.release_name }}
-          prerelease: ${{ github.event.inputs.is_prerelease }}
+          name: ${{ env.RELEASE_NAME }}
           body: |
-            Linux kernel ${{ github.event.inputs.linux_kernel_version }}
-            Buildroot ${{ github.event.inputs.buildroot_version }}
-            ${{ github.event.inputs.extra_description }}
-          tag_name: ${{ github.event.inputs.tag_name }}
+            Linux kernel ${{ env.LINUX_KERNEL_VER }}
+            Buildroot ${{ env.BUILDROOT_VER }}
+          tag_name: ${{ env.TAG_NAME }}
           files: |
             distribution-files/arm_Image
             distribution-files/arm_Image.sha256

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -18,7 +18,22 @@ defaults:
     shell: bash
 
 jobs:
+  input_checks:
+    runs-on: ubuntu-22.04
+    
+    steps:
+      - name: Make sure the official FOG version input box was entered if the is official checkbox was selected
+        run: |
+          is_official="${{ inputs.is_official_release }}"
+          fog_version="${{ inputs.official_fog_version }}"
+          if [[ $is_official == "true" && $fog_version == "" ]]; then
+            echo "Official FOG Version was not entered!"
+            exit 1
+          fi
+
   build_kernel_arm64:
+    needs: input_checks
+
     runs-on: ubuntu-22.04
 
     steps:
@@ -45,6 +60,8 @@ jobs:
           retention-days: 1
 
   build_kernel_x86:
+    needs: input_checks
+
     runs-on: ubuntu-22.04
 
     steps:
@@ -71,6 +88,8 @@ jobs:
           retention-days: 1
 
   build_kernel_x64:
+    needs: input_checks
+
     runs-on: ubuntu-22.04
 
     steps:
@@ -97,6 +116,8 @@ jobs:
           retention-days: 1
 
   build_initrd_arm64:
+    needs: input_checks
+
     runs-on: ubuntu-22.04
 
     steps:
@@ -130,6 +151,8 @@ jobs:
           retention-days: 30
 
   build_initrd_x86:
+    needs: input_checks
+
     runs-on: ubuntu-22.04
 
     steps:
@@ -163,6 +186,8 @@ jobs:
           retention-days: 30
 
   build_initrd_x64:
+    needs: input_checks
+
     runs-on: ubuntu-22.04
 
     steps:
@@ -217,7 +242,7 @@ jobs:
 
       - name: Set release name variable
         run: |
-          echo "RELEASE_NAME=\"Latest from $(date '+%Y-%d-%m')\"" >> $GITHUB_ENV
+          echo "RELEASE_NAME=\"Latest from $(date '+%Y-%m-%d')\"" >> $GITHUB_ENV
           
       - name: Set tag name variable
         run: |
@@ -231,7 +256,7 @@ jobs:
         run: |
           echo "BUILDROOT_VER=$(cat build.sh | sed -n -e 's/^.*BUILDROOT_VERSION=//p' | cut -d\' -f 2)" >> $GITHUB_ENV
 
-      - name: Official FOG release
+      - name: Set release name and tag name variable if it is an Official FOG release
         run: |
           is_official="${{ inputs.is_official_release }}"
           fog_version="${{ inputs.official_fog_version }}"


### PR DESCRIPTION
These are the new inputs.

![Screenshot from 2023-04-02 19-21-51](https://user-images.githubusercontent.com/12180281/229397182-48518938-9473-4a9b-8d26-fea86831d93c.png)

---

If the checkbox is not selected and nothing is entered to the input field, then the release will come out like this:
![Screenshot from 2023-04-02 19-24-54](https://user-images.githubusercontent.com/12180281/229397514-a385ca79-28d6-4492-a786-b48cee9f30b6.png)

---

If the checkbox is selected and the FOG version is entered, then the release will come out like this:
![Screenshot from 2023-04-02 19-26-59](https://user-images.githubusercontent.com/12180281/229397763-11b0bf14-0575-4df9-b9e0-21a5abfdbfaf.png)
Whatever is entered in the input text field will appear in the release name `FOG (ENTERED TEXT) kernels and inits`

---

There is now a preceding job that runs before all the builds. This preceding job checks to make sure that the input text field is not empty if the `Official Release?` checkbox is selected and vice versa.

Fixes #65 