### PR TITLE
FOS: DRY refactor of init libs + checkStatus result-handler

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -214,16 +214,7 @@ expandPartition() {
         ntfs)
             dots "Resizing $fstype volume ($part)"
             yes | ntfsresize $part -fbP >/tmp/tmpoutput.txt 2>&1
-            case $? in
-                0)
-                    echo "Done"
-                    ;;
-                *)
-                    echo "Failed"
-                    debugPause
-                    handleError "Could not resize $part (${FUNCNAME[0]})\n   Info: $(cat /tmp/tmpoutput.txt)\n   Args Passed: $*"
-                    ;;
-            esac
+            checkStatus $? "done" "Could not resize $part (${FUNCNAME[0]})\n   Info: $(cat /tmp/tmpoutput.txt)\n   Args Passed: $*"
             debugPause
             resetFlag "$part"
             ;;
@@ -243,15 +234,7 @@ expandPartition() {
                     ;;
             esac
             resize2fs $part >/tmp/resize2fs.txt 2>&1
-            case $? in
-                0)
-                    ;;
-                *)
-                    echo "Failed"
-                    debugPause
-                    handleError "Could not resize $part (${FUNCNAME[0]})\n   Info: $(cat /tmp/resize2fs.txt)\n   Args Passed: $*"
-                    ;;
-            esac
+            checkStatus $? "silent" "Could not resize $part (${FUNCNAME[0]})\n   Info: $(cat /tmp/resize2fs.txt)\n   Args Passed: $*"
             e2fsck -fp $part >/tmp/e2fsck.txt 2>&1
             case $? in
                 0)
@@ -510,29 +493,11 @@ prepareUploadLocation() {
     debugPause
     dots "Setting permission on $imagePath"
     chmod -R 775 $imagePath >/dev/null 2>&1
-    case $? in
-        0)
-            echo "Done"
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError "Failed to set permissions (${FUNCNAME[0]})\n   Args Passed: $*"
-            ;;
-    esac
+    checkStatus $? "done" "Failed to set permissions (${FUNCNAME[0]})\n   Args Passed: $*"
     debugPause
     dots "Removing any pre-existing files"
     rm -Rf $imagePath/* >/dev/null 2>&1
-    case $? in
-        0)
-            echo "Done"
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError "Could not clean files (${FUNCNAME[0]})\n   Args Passed: $*"
-            ;;
-    esac
+    checkStatus $? "done" "Could not clean files (${FUNCNAME[0]})\n   Args Passed: $*"
     debugPause
 }
 # Moves partitions if possible for upload (resizable images only)
@@ -673,16 +638,7 @@ shrinkPartition() {
                 debugPause
                 dots "Resizing filesystem"
                 yes | ntfsresize -fs ${sizentfsresize}k ${part} >/tmp/output.txt 2>&1
-                case $? in
-                    0)
-                        echo "Done"
-                        ;;
-                    *)
-                        echo "Failed"
-                        debugPause
-                        handleError "Could not resize disk (${FUNCNAME[0]})\n   Info: $(cat /tmp/output.txt)\n   Args Passed: $*"
-                        ;;
-                esac
+                checkStatus $? "done" "Could not resize disk (${FUNCNAME[0]})\n   Info: $(cat /tmp/output.txt)\n   Args Passed: $*"
             fi
             if [[ $do_resizepart -eq 1 ]]; then
                 debugPause
@@ -711,16 +667,7 @@ shrinkPartition() {
         extfs)
             dots "Checking $fstype volume ($part)"
             e2fsck -fp $part >/tmp/e2fsck.txt 2>&1
-            case $? in
-                0)
-                    echo "Done"
-                    ;;
-                *)
-                    echo "Failed"
-                    debugPause
-                    handleError "e2fsck failed to check $part (${FUNCNAME[0]})\n   Info: $(cat /tmp/e2fsck.txt)\n   Args Passed: $*"
-                    ;;
-            esac
+            checkStatus $? "done" "e2fsck failed to check $part (${FUNCNAME[0]})\n   Info: $(cat /tmp/e2fsck.txt)\n   Args Passed: $*"
             debugPause
             extminsize=$(resize2fs -P $part 2>/dev/null | awk -F': ' '{print $2}')
             block_size=$(dumpe2fs -h $part 2>/dev/null | awk '/^Block[ ]size:/{print $3}')
@@ -730,16 +677,7 @@ shrinkPartition() {
             [[ -z $sizeextresize || $sizeextresize -lt 1 ]] && handleError "Error calculating the new size of extfs ($part) (${FUNCNAME[0]})\n   Args Passed: $*"
             dots "Shrinking $fstype volume ($part)"
             resize2fs $part -M >/tmp/resize2fs.txt 2>&1
-            case $? in
-                0)
-                    echo "Done"
-                    ;;
-                *)
-                    echo "Failed"
-                    debugPause
-                    handleError "Could not shrink $fstype volume ($part) (${FUNCNAME[0]})\n   Info: $(cat /tmp/resize2fs.txt)\n   Args Passed: $*"
-                    ;;
-            esac
+            checkStatus $? "done" "Could not shrink $fstype volume ($part) (${FUNCNAME[0]})\n   Info: $(cat /tmp/resize2fs.txt)\n   Args Passed: $*"
             debugPause
             dots "Shrinking $part partition"
             resizePartition "$part" "$sizeextresize" "$imagePath"
@@ -1047,17 +985,7 @@ changeHostname() {
     fi
     umount /ntfs >/dev/null 2>&1
     ntfs-3g -o remove_hiberfile,rw $part /ntfs >/tmp/ntfs-mount-output 2>&1
-    case $? in
-        0)
-            echo "Done"
-            debugPause
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError " * Could not mount $part (${FUNCNAME[0]})\n    Args Passed: $*\n    Reason: $(cat /tmp/ntfs-mount-output | tr -d \\0)"
-            ;;
-    esac
+    checkStatus $? "done-pause" " * Could not mount $part (${FUNCNAME[0]})\n    Args Passed: $*\n    Reason: $(cat /tmp/ntfs-mount-output | tr -d \\0)"
     if [[ ! -f /usr/share/fog/lib/EOFREG ]]; then
         case $osid in
             1)
@@ -1113,28 +1041,10 @@ fixWin7boot() {
     dots "Mounting partition"
     if [[ ! -d /bcdstore ]]; then
         mkdir -p /bcdstore >/dev/null 2>&1
-        case $? in
-            0)
-                ;;
-            *)
-                echo "Failed"
-                debugPause
-                handleError " * Could not create mount location (${FUNCNAME[0]})\n    Args Passed: $*"
-                ;;
-        esac
+        checkStatus $? "silent" " * Could not create mount location (${FUNCNAME[0]})\n    Args Passed: $*"
     fi
     ntfs-3g -o remove_hiberfile,rw $part /bcdstore >/tmp/ntfs-mount-output 2>&1
-    case $? in
-        0)
-            echo "Done"
-            debugPause
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError " * Could not mount $part (${FUNCNAME[0]})\n    Args Passed: $*\n    Reason: $(cat /tmp/ntfs-mount-output | tr -d \\0)"
-            ;;
-    esac
+    checkStatus $? "done-pause" " * Could not mount $part (${FUNCNAME[0]})\n    Args Passed: $*\n    Reason: $(cat /tmp/ntfs-mount-output | tr -d \\0)"
     if [[ ! -f /bcdstore/Boot/BCD ]]; then
         umount /bcdstore >/dev/null 2>&1
         return
@@ -1202,15 +1112,7 @@ clearMountedDevices() {
                 ntfs)
                     dots "Clearing part ($part)"
                     ntfs-3g -o remove_hiberfile,rw $part /ntfs >/tmp/ntfs-mount-output 2>&1
-                    case $? in
-                        0)
-                            ;;
-                        *)
-                            echo "Failed"
-                            debugPause
-                            handleError " * Could not mount $part (${FUNCNAME[0]})\n    Args Passed: $*\n    Reason: $(cat /tmp/ntfs-mount-output | tr -d \\0)"
-                            ;;
-                    esac
+                    checkStatus $? "silent" " * Could not mount $part (${FUNCNAME[0]})\n    Args Passed: $*\n    Reason: $(cat /tmp/ntfs-mount-output | tr -d \\0)"
                     if [[ ! -f $REG_LOCAL_MACHINE_7 ]]; then
                         echo "Reg file not found"
                         debugPause
@@ -1253,29 +1155,11 @@ removePageFile() {
                     dots "Mounting partition ($part)"
                     if [[ ! -d /ntfs ]]; then
                         mkdir -p /ntfs >/dev/null 2>&1
-                        case $? in
-                            0)
-                                ;;
-                            *)
-                                echo "Failed"
-                                debugPause
-                                handleError " * Could not create mount location (${FUNCNAME[0]})\n    Args Passed: $*"
-                                ;;
-                        esac
+                        checkStatus $? "silent" " * Could not create mount location (${FUNCNAME[0]})\n    Args Passed: $*"
                     fi
                     umount /ntfs >/dev/null 2>&1
                     ntfs-3g -o remove_hiberfile,rw $part /ntfs >/tmp/ntfs-mount-output 2>&1
-                    case $? in
-                        0)
-                            echo "Done"
-                            debugPause
-                            ;;
-                        *)
-                            echo "Failed"
-                            debugPause
-                            handleError " * Could not mount $part (${FUNCNAME[0]})\n    Args Passed: $*\n    Reason: $(cat /tmp/ntfs-mount-output | tr -d \\0)"
-                            ;;
-                    esac
+                    checkStatus $? "done-pause" " * Could not mount $part (${FUNCNAME[0]})\n    Args Passed: $*\n    Reason: $(cat /tmp/ntfs-mount-output | tr -d \\0)"
                     if [[ -f /ntfs/pagefile.sys ]]; then
                         dots "Removing page file"
                         rm -rf /ntfs/pagefile.sys >/dev/null 2>&1
@@ -1692,86 +1576,21 @@ correctVistaMBR() {
     [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
     dots "Correcting Vista MBR"
     dd if=$disk of=/tmp.mbr count=1 bs=512 >/dev/null 2>&1
-    case $? in
-        0)
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError "Could not create backup (${FUNCNAME[0]})\n   Args Passed: $*"
-            ;;
-    esac
+    checkStatus $? "silent" "Could not create backup (${FUNCNAME[0]})\n   Args Passed: $*"
     xxd /tmp.mbr /tmp.mbr.txt >/dev/null 2>&1
-    case $? in
-        0)
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError "xxd command failed (${FUNCNAME[0]})\n   Args Passed: $*"
-            ;;
-    esac
+    checkStatus $? "silent" "xxd command failed (${FUNCNAME[0]})\n   Args Passed: $*"
     rm /tmp.mbr >/dev/null 2>&1
-    case $? in
-        0)
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError "Couldn't remove /tmp.mbr file (${FUNCNAME[0]})\n   Args Passed: $*"
-            ;;
-    esac
+    checkStatus $? "silent" "Couldn't remove /tmp.mbr file (${FUNCNAME[0]})\n   Args Passed: $*"
     fogmbrfix /tmp.mbr.txt /tmp.mbr.fix.txt >/dev/null 2>&1
-    case $? in
-        0)
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError "fogmbrfix failed to operate (${FUNCNAME[0]})\n   Args Passed: $*"
-            ;;
-    esac
+    checkStatus $? "silent" "fogmbrfix failed to operate (${FUNCNAME[0]})\n   Args Passed: $*"
     rm /tmp.mbr.txt >/dev/null 2>&1
-    case $? in
-        0)
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError "Could not remove the text file (${FUNCNAME[0]})\n   Args Passed: $*"
-            ;;
-    esac
+    checkStatus $? "silent" "Could not remove the text file (${FUNCNAME[0]})\n   Args Passed: $*"
     xxd -r /tmp.mbr.fix.txt /mbr.mbr >/dev/null 2>&1
-    case $? in
-        0)
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError "Could not run second xxd command (${FUNCNAME[0]})\n   Args Passed: $*"
-            ;;
-    esac
+    checkStatus $? "silent" "Could not run second xxd command (${FUNCNAME[0]})\n   Args Passed: $*"
     rm /tmp.mbr.fix.txt >/dev/null 2>&1
-    case $? in
-        0)
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError "Could not remove the fix file (${FUNCNAME[0]})\n   Args Passed: $*"
-            ;;
-    esac
+    checkStatus $? "silent" "Could not remove the fix file (${FUNCNAME[0]})\n   Args Passed: $*"
     dd if=/mbr.mbr of="$disk" count=1 bs=512 >/dev/null 2>&1
-    case $? in
-        0)
-            echo "Done"
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError "Could not apply fixed MBR (${FUNCNAME[0]})\n   Args Passed: $*"
-            ;;
-    esac
+    checkStatus $? "done" "Could not apply fixed MBR (${FUNCNAME[0]})\n   Args Passed: $*"
     debugPause
 }
 # Prints an error with visible information
@@ -2017,6 +1836,40 @@ debugPause() {
             ;;
         *)
             return
+            ;;
+    esac
+}
+# Handle the exit status of the immediately-preceding command using the shared
+# Done/Failed idiom. Usage:
+#   checkStatus <status> <success-mode> <error-message> [extra handleError args...]
+# <success-mode> controls what is emitted when <status> is 0:
+#   done        -> echo "Done"
+#   done-pause  -> echo "Done"; debugPause
+#   silent      -> emit nothing
+# On any non-zero status: echo "Failed"; debugPause; handleError <message> <extra...>.
+# The caller expands ${FUNCNAME[0]} and $* into <error-message> itself, so the
+# function name and args shown match the original inline case block exactly.
+checkStatus() {
+    local status="$1" mode="$2" msg="$3"
+    shift 3
+    case $status in
+        0)
+            case $mode in
+                done)
+                    echo "Done"
+                    ;;
+                done-pause)
+                    echo "Done"
+                    debugPause
+                    ;;
+                silent)
+                    ;;
+            esac
+            ;;
+        *)
+            echo "Failed"
+            debugPause
+            handleError "$msg" "$@"
             ;;
     esac
 }
@@ -2489,16 +2342,7 @@ runFixparts() {
     echo
     dots "Attempting fixparts"
     fixparts $disk </usr/share/fog/lib/EOFFIXPARTS >/dev/null 2>&1
-    case $? in
-        0)
-            echo "Done"
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError "Could not fix partition layout (${FUNCNAME[0]})\n   Args Passed: $*" "yes"
-            ;;
-    esac
+    checkStatus $? "done" "Could not fix partition layout (${FUNCNAME[0]})\n   Args Passed: $*" "yes"
     debugPause
     runPartprobe "$disk"
 }

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -101,55 +101,45 @@ getGraphics() {
 # Gets the information from the system for inventory
 doInventory() {
     getGraphics
-    sysman=$(dmidecode -s system-manufacturer)
-    sysproduct=$(dmidecode -s system-product-name)
-    sysversion=$(dmidecode -s system-version)
-    sysserial=$(dmidecode -s system-serial-number)
-    sysuuid=$(dmidecode -s system-uuid)
+    # Uniform "dmidecode -s <keyword>" lookups, driven from a var:keyword list.
+    local dmifield
+    for dmifield in \
+        sysman:system-manufacturer \
+        sysproduct:system-product-name \
+        sysversion:system-version \
+        sysserial:system-serial-number \
+        sysuuid:system-uuid \
+        biosversion:bios-version \
+        biosvendor:bios-vendor \
+        biosdate:bios-release-date \
+        mbman:baseboard-manufacturer \
+        mbproductname:baseboard-product-name \
+        mbversion:baseboard-version \
+        mbserial:baseboard-serial-number \
+        mbasset:baseboard-asset-tag \
+        cpuman:processor-manufacturer \
+        cpuversion:processor-version \
+        caseman:chassis-manufacturer \
+        casever:chassis-version \
+        caseserial:chassis-serial-number \
+        caseasset:chassis-asset-tag; do
+        printf -v "${dmifield%%:*}" '%s' "$(dmidecode -s "${dmifield#*:}")"
+    done
+    # Non-uniform inventory items kept explicit (different tools/parsing).
     sysuuid=${sysuuid,,}
     systype=$(dmidecode -t 3 | grep Type:)
-    biosversion=$(dmidecode -s bios-version)
-    biosvendor=$(dmidecode -s bios-vendor)
-    biosdate=$(dmidecode -s bios-release-date)
-    mbman=$(dmidecode -s baseboard-manufacturer)
-    mbproductname=$(dmidecode -s baseboard-product-name)
-    mbversion=$(dmidecode -s baseboard-version)
-    mbserial=$(dmidecode -s baseboard-serial-number)
-    mbasset=$(dmidecode -s baseboard-asset-tag)
-    cpuman=$(dmidecode -s processor-manufacturer)
-    cpuversion=$(dmidecode -s processor-version)
     cpucurrent=$(dmidecode -t 4 | grep 'Current Speed:' | head -n1)
     cpumax=$(dmidecode -t 4 | grep 'Max Speed:' | head -n1)
     mem=$(cat /proc/meminfo | grep MemTotal | tr -d \\0)
     hdinfo=$(hdparm -i $hd 2>/dev/null | grep Model= || smartctl -i $hd | grep -A2 "Model Number" | awk -F ":" '/Model Number:/{gsub(/ /,""); modelno=$NF};/Serial Number:/{gsub(/ /,""); serialno=$NF};/Firmware Version:/{gsub(/ /,""); fwrev=$NF; print "model="modelno", fwrev="fwrev", serialno="serialno}')
-    caseman=$(dmidecode -s chassis-manufacturer)
-    casever=$(dmidecode -s chassis-version)
-    caseserial=$(dmidecode -s chassis-serial-number)
-    caseasset=$(dmidecode -s chassis-asset-tag)
-    sysman64=$(echo $sysman | base64)
-    sysproduct64=$(echo $sysproduct | base64)
-    sysversion64=$(echo $sysversion | base64)
-    sysserial64=$(echo $sysserial | base64)
-    sysuuid64=$(echo $sysuuid | base64)
-    systype64=$(echo $systype | base64)
-    biosversion64=$(echo $biosversion | base64)
-    biosvendor64=$(echo $biosvendor | base64)
-    biosdate64=$(echo $biosdate | base64)
-    mbman64=$(echo $mbman | base64)
-    mbproductname64=$(echo $mbproductname | base64)
-    mbversion64=$(echo $mbversion | base64)
-    mbserial64=$(echo $mbserial | base64)
-    mbasset64=$(echo $mbasset | base64)
-    cpuman64=$(echo $cpuman | base64)
-    cpuversion64=$(echo $cpuversion | base64)
-    cpucurrent64=$(echo $cpucurrent | base64)
-    cpumax64=$(echo $cpumax | base64)
-    mem64=$(echo $mem | base64)
-    hdinfo64=$(echo $hdinfo | base64)
-    caseman64=$(echo $caseman | base64)
-    casever64=$(echo $casever | base64)
-    caseserial64=$(echo $caseserial | base64)
-    caseasset64=$(echo $caseasset | base64)
+    # base64-encode each inventory field into its <name>64 counterpart.
+    local invfield
+    for invfield in sysman sysproduct sysversion sysserial sysuuid systype \
+        biosversion biosvendor biosdate mbman mbproductname mbversion mbserial \
+        mbasset cpuman cpuversion cpucurrent cpumax mem hdinfo caseman casever \
+        caseserial caseasset; do
+        printf -v "${invfield}64" '%s' "$(echo ${!invfield} | base64)"
+    done
 }
 # Gets the location of the SAM registry if found
 getSAMLoc() {
@@ -1024,26 +1014,28 @@ changeHostname() {
     local part="$1"
     [[ -z $part ]] && handleError "No partition passed (${FUNCNAME[0]})\n   Args Passed: $*"
     [[ -z $hostname || $hostearly -eq 0 ]] && return
-    REG_HOSTNAME_KEY1="\ControlSet001\Services\Tcpip\Parameters\NV Hostname"
-    REG_HOSTNAME_KEY2="\ControlSet001\Services\Tcpip\Parameters\Hostname"
-    REG_HOSTNAME_KEY3="\ControlSet001\Services\Tcpip\Parameters\NV HostName"
-    REG_HOSTNAME_KEY4="\ControlSet001\Services\Tcpip\Parameters\HostName"
-    REG_HOSTNAME_KEY5="\ControlSet001\Control\ComputerName\ActiveComputerName\ComputerName"
-    REG_HOSTNAME_KEY6="\ControlSet001\Control\ComputerName\ComputerName\ComputerName"
-    REG_HOSTNAME_KEY7="\ControlSet001\services\Tcpip\Parameters\NV Hostname"
-    REG_HOSTNAME_KEY8="\ControlSet001\services\Tcpip\Parameters\Hostname"
-    REG_HOSTNAME_KEY9="\ControlSet001\services\Tcpip\Parameters\NV HostName"
-    REG_HOSTNAME_KEY10="\ControlSet001\services\Tcpip\Parameters\HostName"
-    REG_HOSTNAME_KEY11="\CurrentControlSet\Services\Tcpip\Parameters\NV Hostname"
-    REG_HOSTNAME_KEY12="\CurrentControlSet\Services\Tcpip\Parameters\Hostname"
-    REG_HOSTNAME_KEY13="\CurrentControlSet\Services\Tcpip\Parameters\NV HostName"
-    REG_HOSTNAME_KEY14="\CurrentControlSet\Services\Tcpip\Parameters\HostName"
-    REG_HOSTNAME_KEY15="\CurrentControlSet\Control\ComputerName\ActiveComputerName\ComputerName"
-    REG_HOSTNAME_KEY16="\CurrentControlSet\Control\ComputerName\ComputerName\ComputerName"
-    REG_HOSTNAME_KEY17="\CurrentControlSet\services\Tcpip\Parameters\NV Hostname"
-    REG_HOSTNAME_KEY18="\CurrentControlSet\services\Tcpip\Parameters\Hostname"
-    REG_HOSTNAME_KEY19="\CurrentControlSet\services\Tcpip\Parameters\NV HostName"
-    REG_HOSTNAME_KEY20="\CurrentControlSet\services\Tcpip\Parameters\HostName"
+    local reg_hostname_keys=(
+        "\ControlSet001\Services\Tcpip\Parameters\NV Hostname"
+        "\ControlSet001\Services\Tcpip\Parameters\Hostname"
+        "\ControlSet001\Services\Tcpip\Parameters\NV HostName"
+        "\ControlSet001\Services\Tcpip\Parameters\HostName"
+        "\ControlSet001\Control\ComputerName\ActiveComputerName\ComputerName"
+        "\ControlSet001\Control\ComputerName\ComputerName\ComputerName"
+        "\ControlSet001\services\Tcpip\Parameters\NV Hostname"
+        "\ControlSet001\services\Tcpip\Parameters\Hostname"
+        "\ControlSet001\services\Tcpip\Parameters\NV HostName"
+        "\ControlSet001\services\Tcpip\Parameters\HostName"
+        "\CurrentControlSet\Services\Tcpip\Parameters\NV Hostname"
+        "\CurrentControlSet\Services\Tcpip\Parameters\Hostname"
+        "\CurrentControlSet\Services\Tcpip\Parameters\NV HostName"
+        "\CurrentControlSet\Services\Tcpip\Parameters\HostName"
+        "\CurrentControlSet\Control\ComputerName\ActiveComputerName\ComputerName"
+        "\CurrentControlSet\Control\ComputerName\ComputerName\ComputerName"
+        "\CurrentControlSet\services\Tcpip\Parameters\NV Hostname"
+        "\CurrentControlSet\services\Tcpip\Parameters\Hostname"
+        "\CurrentControlSet\services\Tcpip\Parameters\NV HostName"
+        "\CurrentControlSet\services\Tcpip\Parameters\HostName"
+    )
     dots "Mounting directory"
     if [[ ! -d /ntfs ]]; then
         mkdir -p /ntfs >/dev/null 2>&1
@@ -1067,26 +1059,6 @@ changeHostname() {
             ;;
     esac
     if [[ ! -f /usr/share/fog/lib/EOFREG ]]; then
-        key1="$REG_HOSTNAME_KEY1"
-        key2="$REG_HOSTNAME_KEY2"
-        key3="$REG_HOSTNAME_KEY3"
-        key4="$REG_HOSTNAME_KEY4"
-        key5="$REG_HOSTNAME_KEY5"
-        key6="$REG_HOSTNAME_KEY6"
-        key7="$REG_HOSTNAME_KEY7"
-        key8="$REG_HOSTNAME_KEY8"
-        key9="$REG_HOSTNAME_KEY9"
-        key10="$REG_HOSTNAME_KEY10"
-        key11="$REG_HOSTNAME_KEY11"
-        key12="$REG_HOSTNAME_KEY12"
-        key13="$REG_HOSTNAME_KEY13"
-        key14="$REG_HOSTNAME_KEY14"
-        key15="$REG_HOSTNAME_KEY15"
-        key16="$REG_HOSTNAME_KEY16"
-        key17="$REG_HOSTNAME_KEY17"
-        key18="$REG_HOSTNAME_KEY18"
-        key19="$REG_HOSTNAME_KEY19"
-        key20="$REG_HOSTNAME_KEY20"
         case $osid in
             1)
                 regfile="$REG_LOCAL_MACHINE_XP"
@@ -1095,49 +1067,16 @@ changeHostname() {
                 regfile="$REG_LOCAL_MACHINE_7"
                 ;;
         esac
-        echo "ed $key1" >/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key2" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key3" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key4" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key5" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key6" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key7" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key8" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key9" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key10" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key11" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key12" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key13" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key14" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key15" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key16" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key17" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key18" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key19" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "ed $key20" >>/usr/share/fog/lib/EOFREG
-        echo "$hostname" >>/usr/share/fog/lib/EOFREG
-        echo "q" >> /usr/share/fog/lib/EOFREG
-        echo "y" >> /usr/share/fog/lib/EOFREG
-        echo >> /usr/share/fog/lib/EOFREG
+        local regkey
+        {
+            for regkey in "${reg_hostname_keys[@]}"; do
+                echo "ed $regkey"
+                echo "$hostname"
+            done
+            echo "q"
+            echo "y"
+            echo
+        } >/usr/share/fog/lib/EOFREG
     fi
     if [[ -e $regfile ]]; then
         dots "Changing hostname"
@@ -2100,54 +2039,28 @@ majorDebugPause() {
     echo " * Press [Enter] key to continue"
     read -p "$*"
 }
-swapUUIDFileName() {
+# Build "$imagePath/d<disk_number>.<suffix>" into the named variable. Validation
+# errors report the calling helper (FUNCNAME[1]), not this generator.
+partitionFileName() {
     local imagePath="$1"  # e.g. /net/dev/foo
     local disk_number="$2"    # e.g. 1
-    [[ -z $imagePath ]] && handleError "No image path passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $disk_number ]] && handleError "No drive number passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    swapuuidfilename="$imagePath/d${disk_number}.original.swapuuids"
+    local suffix="$3"
+    local __outvar="$4"
+    [[ -z $imagePath ]] && handleError "No image path passed (${FUNCNAME[1]})\n   Args Passed: $*"
+    [[ -z $disk_number ]] && handleError "No disk number passed (${FUNCNAME[1]})\n   Args Passed: $*"
+    printf -v "$__outvar" '%s' "$imagePath/d${disk_number}.${suffix}"
 }
-sfdiskPartitionFileName() {
-    local imagePath="$1"  # e.g. /net/dev/foo
-    local disk_number="$2"    # e.g. 1
-    [[ -z $imagePath ]] && handleError "No image path passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $disk_number ]] && handleError "No drive number passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    sfdiskoriginalpartitionfilename="$imagePath/d${disk_number}.partitions"
-}
-sfdiskLegacyOriginalPartitionFileName() {
-    local imagePath="$1"  # e.g. /net/dev/foo
-    local disk_number="$2"    # e.g. 1
-    [[ -z $imagePath ]] && handleError "No image path passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $disk_number ]] && handleError "No drive number passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    sfdisklegacyoriginalpartitionfilename="$imagePath/d${disk_number}.original.partitions"
-}
-sfdiskMinimumPartitionFileName() {
-    local imagePath="$1"  # e.g. /net/dev/foo
-    local disk_number="$2"    # e.g. 1
-    [[ -z $imagePath ]] && handleError "No image path passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $disk_number ]] && handleError "No drive number passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    sfdiskminimumpartitionfilename="$imagePath/d${disk_number}.minimum.partitions"
-}
+swapUUIDFileName() { partitionFileName "$1" "$2" "original.swapuuids" swapuuidfilename; }
+sfdiskPartitionFileName() { partitionFileName "$1" "$2" "partitions" sfdiskoriginalpartitionfilename; }
+sfdiskLegacyOriginalPartitionFileName() { partitionFileName "$1" "$2" "original.partitions" sfdisklegacyoriginalpartitionfilename; }
+sfdiskMinimumPartitionFileName() { partitionFileName "$1" "$2" "minimum.partitions" sfdiskminimumpartitionfilename; }
+fixedSizePartitionsFileName() { partitionFileName "$1" "$2" "fixed_size_partitions" fixed_size_file; }
 sfdiskOriginalPartitionFileName() {
     local imagePath="$1"  # e.g. /net/dev/foo
     local disk_number="$2"    # e.g. 1
     [[ -z $imagePath ]] && handleError "No image path passed (${FUNCNAME[0]})\n   Args Passed: $*"
     [[ -z $disk_number ]] && handleError "No disk number passed (${FUNCNAME[0]})\n   Args Passed: $*"
     sfdiskPartitionFileName "$imagePath" "$disk_number"
-}
-sgdiskOriginalPartitionFileName() {
-    local imagePath="$1"  # e.g. /net/dev/foo
-    local disk_number="$2"    # e.g. 1
-    [[ -z $imagePath ]] && handleError "No image path passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $disk_number ]] && handleError "No disk number passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    sgdiskoriginalpartitionfilename="$imagePath/d${disk_number}.sgdisk.original.partitions"
-}
-fixedSizePartitionsFileName() {
-    local imagePath="$1"  # e.g. /net/dev/foo
-    local disk_number="$2"    # e.g. 1
-    [[ -z $imagePath ]] && handleError "No image path passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ -z $disk_number ]] && handleError "No disk number passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    fixed_size_file="$imagePath/d${disk_number}.fixed_size_partitions"
 }
 hasGrubFileName() {
     local imagePath="$1"  # e.g. /net/dev/foo

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/partition-funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/partition-funcs.sh
@@ -132,17 +132,7 @@ saveEBR() {
     [[ ! $hasEBR -gt 0 ]] && return
     dots "Saving EBR for ($part)"
     dd if=$part of=$file bs=512 count=1 >/dev/null 2>&1
-    case $? in
-        0)
-            echo "Done"
-            debugPause
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError "Could not backup EBR (${FUNCNAME[0]})\n   Args Passed: $*"
-            ;;
-    esac
+    checkStatus $? "done-pause" "Could not backup EBR (${FUNCNAME[0]})\n   Args Passed: $*"
 }
 # $1 = DriveName  (e.g. /dev/sdb)
 # $2 = DriveNumber  (e.g. 1)
@@ -183,17 +173,7 @@ restoreEBR() {
     [[ ! -e $file ]] && return
     dots "Restoring EBR for ($part)"
     dd of=$part if=$file bs=512 count=1 >/dev/null 2>&1
-    case $? in
-        0)
-            echo "Done"
-            debugPause
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError "Could not reload EBR data (${FUNCNAME[0]})\n   Args Passed: $*"
-            ;;
-    esac
+    checkStatus $? "done-pause" "Could not reload EBR data (${FUNCNAME[0]})\n   Args Passed: $*"
 }
 # $1 = DriveName  (e.g. /dev/sdb)
 # $2 = DriveNumber  (e.g. 1)
@@ -342,16 +322,7 @@ makeSwapSystem() {
     [[ -n $uuid ]] && option="-U $uuid"
     dots "Restoring swap partition"
     mkswap $option $part >/dev/null 2>&1
-    case $? in
-        0)
-            echo "Done"
-            ;;
-        *)
-            echo "Failed"
-            debugPause
-            handleError "Could not create swap on $part (${FUNCNAME[0]})\n   Args Passed: $*"
-            ;;
-    esac
+    checkStatus $? "done" "Could not create swap on $part (${FUNCNAME[0]})\n   Args Passed: $*"
     debugPause
 }
 # $1 is the partition device (e.g. /dev/sda1)

--- a/build.sh
+++ b/build.sh
@@ -101,8 +101,29 @@ installDependencies "$installDep"
 cd "$buildPath" || exit 1
 
 
+# Echo the ARCH / CROSS_COMPILE make flags for an architecture in a given build
+# domain. The kernel and filesystem builds use different 32-bit (i386 vs i486)
+# and arm64 (arm64 vs aarch64) ARCH values, so the domain (fs|kernel) selects
+# the correct set. x64 and any unknown arch get no extra flags.
+function makeFlags() {
+    local arch="$1" domain="$2"
+    case "$arch" in
+        x86)
+            [[ $domain == kernel ]] && echo "ARCH=i386" || echo "ARCH=i486"
+            ;;
+        arm64)
+            [[ $domain == kernel ]] && echo "ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-" || echo "ARCH=aarch64 CROSS_COMPILE=aarch64-linux-gnu-"
+            ;;
+        *)
+            : # x64 and default: no extra flags
+            ;;
+    esac
+}
+
 function buildFilesystem() {
     local arch="$1"
+    local fsflags
+    fsflags=$(makeFlags "$arch" fs)
     brURL="https://buildroot.org/downloads/buildroot-$BUILDROOT_VERSION.tar.xz"
     echo "Preparing buildroot $BUILDROOT_VERSION on $arch build:"
     if [[ ! -d fssource$arch ]]; then
@@ -141,20 +162,8 @@ function buildFilesystem() {
     sed -i "s/^export initversion=[0-9][0-9]*$/export initversion=$(date +%Y%m%d)/" board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
     if [[ ! -f .config ]]; then
         cp "../configs/fs$arch.config" .config
-        case "${arch}" in
-            x64)
-                make oldconfig
-                ;;
-            x86)
-                make ARCH=i486 oldconfig
-                ;;
-            arm64)
-                make ARCH=aarch64 CROSS_COMPILE=aarch64-linux-gnu- oldconfig
-                ;;
-            *)
-                make oldconfig
-                ;;
-        esac
+        # shellcheck disable=SC2086
+        make $fsflags oldconfig
     fi
     echo "Done"
 
@@ -169,36 +178,12 @@ function buildFilesystem() {
     if [[ $confirm != n ]]; then
         read -rp "We are ready to build. Would you like to edit the config file [y|n]?" config
         if [[ $config == y ]]; then
-            case "${arch}" in
-                x64)
-                    make menuconfig
-                    ;;
-                x86)
-                    make ARCH=i486 menuconfig
-                    ;;
-                arm64)
-                    make ARCH=aarch64 CROSS_COMPILE=aarch64-linux-gnu- menuconfig
-                    ;;
-                *)
-                    make menuconfig
-                    ;;
-            esac
+            # shellcheck disable=SC2086
+            make $fsflags menuconfig
         else
             echo "Ok, running make oldconfig instead to ensure the config is clean."
-            case "${arch}" in
-                x64)
-                    make oldconfig
-                    ;;
-                x86)
-                    make ARCH=i486 oldconfig
-                    ;;
-                arm64)
-                    make ARCH=aarch64 CROSS_COMPILE=aarch64-linux-gnu- oldconfig
-                    ;;
-                *)
-                    make oldconfig
-                    ;;
-            esac
+            # shellcheck disable=SC2086
+            make $fsflags oldconfig
         fi
         read -rp "We are ready to build are you [y|n]?" ready
         if [[ $ready == n ]]; then
@@ -209,45 +194,15 @@ function buildFilesystem() {
     fi
 
     if [[ $verbose == "y" ]]; then
-        case "${arch}" in
-            x64)
-                make | tee "buildroot$arch.log"
-                status=${PIPESTATUS[0]}
-                ;;
-            x86)
-                make ARCH=i486 | tee "buildroot$arch.log"
-                status=${PIPESTATUS[0]}
-                ;;
-            arm64)
-                make ARCH=aarch64 CROSS_COMPILE=aarch64-linux-gnu- | tee "buildroot$arch.log"
-                status=${PIPESTATUS[0]}
-                ;;
-            *)
-                make | tee "buildroot$arch.log"
-                status=${PIPESTATUS[0]}
-                ;;
-        esac
+        # shellcheck disable=SC2086
+        make $fsflags | tee "buildroot$arch.log"
+        status=${PIPESTATUS[0]}
     else
         bash -c "while true; do echo \$(date) - building ...; sleep 30s; done" &
         PING_LOOP_PID=$!
-        case "${arch}" in
-            x64)
-                make > "buildroot$arch.log" 2>&1
-                status=$?
-                ;;
-            x86)
-                make ARCH=i486 > "buildroot$arch.log" 2>&1
-                status=$?
-                ;;
-            arm64)
-                make ARCH=aarch64 CROSS_COMPILE=aarch64-linux-gnu- > "buildroot$arch.log" 2>&1
-                status=$?
-                ;;
-            *)
-                make > "buildroot$arch.log" 2>&1
-                status=$?
-                ;;
-        esac
+        # shellcheck disable=SC2086
+        make $fsflags > "buildroot$arch.log" 2>&1
+        status=$?
         kill $PING_LOOP_PID
     fi
 
@@ -275,6 +230,10 @@ function buildFilesystem() {
 
 function buildKernel() {
     local arch="$1"
+    local kflags ktarget
+    kflags=$(makeFlags "$arch" kernel)
+    ktarget=bzImage
+    [[ $arch == arm64 ]] && ktarget=Image
     kernelURL="https://www.kernel.org/pub/linux/kernel/v${KERNEL_VERSION:0:1}.x/linux-$KERNEL_VERSION.tar.xz"
     echo "Preparing kernel $KERNEL_VERSION on $arch build:"
     [[ -d kernelsource$arch ]] && rm -rf "kernelsource$arch"
@@ -329,58 +288,19 @@ function buildKernel() {
     if [[ $confirm != n ]]; then
         read -rp "We are ready to build. Would you like to edit the config file [y|n]?" config
         if [[ $config == y ]]; then
-            case "${arch}" in
-                x64)
-                    make menuconfig
-                    ;;
-                x86)
-                    make ARCH=i386 menuconfig
-                    ;;
-                arm64)
-                    make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- menuconfig
-                    ;;
-                *)
-                    make menuconfig
-                    ;;
-            esac
+            # shellcheck disable=SC2086
+            make $kflags menuconfig
         else
             echo "Ok, running make oldconfig instead to ensure the config is clean."
-            case "${arch}" in
-                x64)
-                    make oldconfig
-                    ;;
-                x86)
-                    make ARCH=i386 oldconfig
-                    ;;
-                arm64)
-                    make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- oldconfig
-                    ;;
-                *)
-                    make oldconfig
-                    ;;
-            esac
+            # shellcheck disable=SC2086
+            make $kflags oldconfig
         fi
         read -rp "We are ready to build are you [y|n]?" ready
         if [[ $ready == y ]]; then
             echo "This make take a long time. Get some coffee, you'll be here a while!"
-            case "${arch}" in
-                x64)
-                    make -j "$(nproc)" bzImage
-                    status=$?
-                    ;;
-                x86)
-                    make ARCH=i386 -j "$(nproc)" bzImage
-                    status=$?
-                    ;;
-                arm64)
-                    make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- -j "$(nproc)" Image
-                    status=$?
-                    ;;
-                *)
-                    make -j "$(nproc)" bzImage
-                    status=$?
-                    ;;
-            esac
+            # shellcheck disable=SC2086
+            make $kflags -j "$(nproc)" $ktarget
+            status=$?
         else
             echo "Nothing to build!? Skipping."
             cd ..
@@ -388,28 +308,11 @@ function buildKernel() {
         fi
         [[ $status -gt 0 ]] && exit $status
     else
-        case "${arch}" in
-            x64)
-                make oldconfig
-                make -j "$(nproc)" bzImage
-                status=$?
-                ;;
-            x86)
-                make ARCH=i386 oldconfig
-                make ARCH=i386 -j "$(nproc)" bzImage
-                status=$?
-                ;;
-            arm64)
-                make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- oldconfig
-                make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- -j "$(nproc)" Image
-                status=$?
-                ;;
-            *)
-                make oldconfig
-                make -j "$(nproc)" bzImage
-                status=$?
-                ;;
-        esac
+        # shellcheck disable=SC2086
+        make $kflags oldconfig
+        # shellcheck disable=SC2086
+        make $kflags -j "$(nproc)" $ktarget
+        status=$?
     fi
     [[ $status -gt 0 ]] && exit $status
     cd ..

--- a/create-usb-image.sh
+++ b/create-usb-image.sh
@@ -37,10 +37,10 @@ grub-install --removable --no-nvram --no-uefi-secure-boot --efi-directory=/mnt -
 echo Download the FOG kernels and inits
 wget -P /mnt/boot/ ${dl_url}/bzImage
 wget -P /mnt/boot/ ${dl_url}/init.xz
-wget -P /mnt/boot/ https://github.com/FOGProject/fogproject/blob/dev-branch/packages/web/service/ipxe/memdisk
-wget -P /mnt/boot/ https://github.com/FOGProject/fogproject/blob/dev-branch/packages/web/service/ipxe/memtest.bin
-wget -P /mnt/boot/ https://github.com/FOGProject/fogproject/blob/dev-branch/packages/tftp/ipxe.krn
-wget -P /mnt/boot/ https://github.com/FOGProject/fogproject/blob/dev-branch/packages/tftp/ipxe.efi
+fp_base="https://github.com/FOGProject/fogproject/blob/dev-branch/packages"
+for f in web/service/ipxe/memdisk web/service/ipxe/memtest.bin tftp/ipxe.krn tftp/ipxe.efi; do
+    wget -P /mnt/boot/ "${fp_base}/${f}"
+done
 
 cat > /mnt/boot/README.txt << 'EOF'
 

--- a/release.sh
+++ b/release.sh
@@ -3,6 +3,21 @@
 . /var/lib/buildkite-agent/github-upload.sh
 [[ -z ${GITHUB_USER} || -z ${GITHUB_TOKEN} ]] && echo "Missing Github information, can't proceed." && exit 1
 
+GITHUB_API="https://api.github.com/repos/FOGProject/fos"
+
+# Authenticated call to the FOS GitHub API. Usage:
+#   github_api <METHOD> <endpoint> [json-data]
+# <endpoint> is appended to $GITHUB_API. Response is written to stdout; the
+# caller redirects to a file or pipes to jq as needed.
+github_api() {
+    local method="$1" endpoint="$2" data="$3"
+    if [[ -n $data ]]; then
+        curl -s -X "$method" -u "${GITHUB_USER}:${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3+json" "${GITHUB_API}${endpoint}" -d "$data"
+    else
+        curl -s -X "$method" -u "${GITHUB_USER}:${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3+json" "${GITHUB_API}${endpoint}"
+    fi
+}
+
 command -v curl
 [[ $? -ne 0 ]] && echo "Package curl not installed, can't proceed." && exit 1
 command -v jq
@@ -15,20 +30,20 @@ if [[ -n "$1" && "$1" =~ ^[0-9]\.[0-9][0-9]*\.[0-9][0-9]*$ ]]; then
     # official release build
     GITHUB_TAG=$1
     GITHUB_NAME="FOG $1 kernels and inits"
-    curl -s -X POST -u ${GITHUB_USER}:${GITHUB_TOKEN} -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/FOGProject/fos/releases -d "{ \"tag_name\":\"${GITHUB_TAG}\", \"name\":\"${GITHUB_NAME}\", \"body\":\"Linux kernel ${KERNEL_VERSION}\nBuildroot ${BUILDROOT_VERSION}\" }" > response.json
+    github_api POST /releases "{ \"tag_name\":\"${GITHUB_TAG}\", \"name\":\"${GITHUB_NAME}\", \"body\":\"Linux kernel ${KERNEL_VERSION}\nBuildroot ${BUILDROOT_VERSION}\" }" > response.json
 elif [[ -n "$1" ]]; then
     # beta testing builds
     GITHUB_TAG="testing"
     GITHUB_NAME="Testing from $(date +%d.%m.%Y)"
-    TESTING_RELEASE_ID=$(curl -s -X GET -u ${GITHUB_USER}:${GITHUB_TOKEN} -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/FOGProject/fos/releases/tags/${GITHUB_TAG} | jq -r .id)
-    HEAD_SHA=$(curl -s -X GET -u ${GITHUB_USER}:${GITHUB_TOKEN} -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/FOGProject/fos/git/refs/heads/${1} | jq -r .object.sha)
-    curl -s -X PATCH -u ${GITHUB_USER}:${GITHUB_TOKEN} -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/FOGProject/fos/git/refs/tags/${GITHUB_TAG} -d "{ \"sha\":\"${HEAD_SHA}\" }" > tag_update_response.json
-    curl -s -X PATCH -u ${GITHUB_USER}:${GITHUB_TOKEN} -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/FOGProject/fos/releases/${TESTING_RELEASE_ID} -d "{ \"tag_name\":\"${GITHUB_TAG}\", \"name\":\"${GITHUB_NAME}\", \"body\":\"Linux kernel ${KERNEL_VERSION}\nBuildroot ${BUILDROOT_VERSION}\nGithub-Branch ${1}\" }" > response.json
+    TESTING_RELEASE_ID=$(github_api GET /releases/tags/${GITHUB_TAG} | jq -r .id)
+    HEAD_SHA=$(github_api GET /git/refs/heads/${1} | jq -r .object.sha)
+    github_api PATCH /git/refs/tags/${GITHUB_TAG} "{ \"sha\":\"${HEAD_SHA}\" }" > tag_update_response.json
+    github_api PATCH /releases/${TESTING_RELEASE_ID} "{ \"tag_name\":\"${GITHUB_TAG}\", \"name\":\"${GITHUB_NAME}\", \"body\":\"Linux kernel ${KERNEL_VERSION}\nBuildroot ${BUILDROOT_VERSION}\nGithub-Branch ${1}\" }" > response.json
 else
     # semi-official development builds
     GITHUB_TAG=$(date +%Y%m%d)
     GITHUB_NAME="Latest from $(date +%d.%m.%Y)"
-    curl -s -X POST -u ${GITHUB_USER}:${GITHUB_TOKEN} -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/FOGProject/fos/releases -d "{ \"tag_name\":\"${GITHUB_TAG}\", \"name\":\"${GITHUB_NAME}\", \"body\":\"Linux kernel ${KERNEL_VERSION}\nBuildroot ${BUILDROOT_VERSION}\" }" > response.json
+    github_api POST /releases "{ \"tag_name\":\"${GITHUB_TAG}\", \"name\":\"${GITHUB_NAME}\", \"body\":\"Linux kernel ${KERNEL_VERSION}\nBuildroot ${BUILDROOT_VERSION}\" }" > response.json
 fi
 
 
@@ -50,9 +65,9 @@ do
     fi
     echo "Uploading ${i}..."
     if [[ -n "$1" ]]; then
-        ASSET_ID=$(curl -s -X GET -u ${GITHUB_USER}:${GITHUB_TOKEN} -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/FOGProject/fos/releases/${GITHUB_RELEASE_ID}/assets | jq -r '.[] | "\(.id),\(.name)"' | grep ",${i}\$"| cut -f1 -d,)
+        ASSET_ID=$(github_api GET /releases/${GITHUB_RELEASE_ID}/assets | jq -r '.[] | "\(.id),\(.name)"' | grep ",${i}\$"| cut -f1 -d,)
         if [[ -n "${ASSET_ID}" ]]; then
-            curl -s -X DELETE -u ${GITHUB_USER}:${GITHUB_TOKEN} -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/FOGProject/fos/releases/assets/${ASSET_ID}
+            github_api DELETE /releases/assets/${ASSET_ID}
         fi
     fi
     curl -s -X POST -u ${GITHUB_USER}:${GITHUB_TOKEN} -H "Content-Type: application/octet-stream" --data-binary "@${i}" "https://uploads.github.com/repos/FOGProject/fos/releases/${GITHUB_RELEASE_ID}/assets?name=${i}" > ${i}.uploaded

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,27 @@
+# FOS dev test harnesses
+
+Dev-only tests. They live outside `Buildroot/board/FOG/FOS/rootfs_overlay`, so
+nothing here ever enters the built init.
+
+## golden/ — output differential harness
+
+Proves that refactors of the shared libraries (`funcs.sh`,
+`partition-funcs.sh`) change no observable output. It drives the
+deterministic, refactor-targeted functions over a fixed battery of inputs and
+compares the result against a committed fixture:
+
+```sh
+tests/golden/run.sh capture   # write fixtures/golden.txt (run BEFORE a refactor)
+tests/golden/run.sh check     # regenerate and assert byte-identical to the fixture
+tests/golden/run.sh print     # dump current output to stdout
+```
+
+Covered: every `*FileName()` output string, the `doInventory` dmidecode and
+base64 blocks, and the `changeHostname` registry `EOFREG` file contents.
+
+The library hardcodes `/usr/share/fog/lib` paths and calls hardware tools, so
+the harness sources a sandbox copy with those paths rewritten and the external
+tools stubbed deterministically. The fixture is therefore machine-independent.
+
+Workflow for a refactor: run `check` on a clean tree (should pass against the
+committed fixture), make the change, run `check` again — it must still pass.

--- a/tests/golden/fixtures/golden.txt
+++ b/tests/golden/fixtures/golden.txt
@@ -1,0 +1,137 @@
+=== FileName helpers ===
+swapUUIDFileName(/net/dev/foo,1)=/net/dev/foo/d1.original.swapuuids
+sfdiskPartitionFileName(/net/dev/foo,1)=/net/dev/foo/d1.partitions
+sfdiskLegacyOriginalPartitionFileName(/net/dev/foo,1)=/net/dev/foo/d1.original.partitions
+sfdiskMinimumPartitionFileName(/net/dev/foo,1)=/net/dev/foo/d1.minimum.partitions
+sfdiskOriginalPartitionFileName(/net/dev/foo,1)=/net/dev/foo/d1.partitions
+fixedSizePartitionsFileName(/net/dev/foo,1)=/net/dev/foo/d1.fixed_size_partitions
+hasGrubFileName(/net/dev/foo,1)=/net/dev/foo/d1.has_grub
+hasGrubFileName(/net/dev/foo,1,sgdisk)=/net/dev/foo/d1.grub.mbr
+EBRFileName(/net/dev/foo,1,5)=/net/dev/foo/d1p5.ebr
+EBRFileName(/net/dev/foo,1,empty)=
+tmpEBRFileName(1,5)=/tmp/d1p5.ebr
+MBRFileName.up(/net/dev/foo,1)=/net/dev/foo/d1.mbr
+MBRFileName.up.sgdisk(/net/dev/foo,1)=/net/dev/foo/d1.mbr
+swapUUIDFileName(/images/host name,2)=/images/host name/d2.original.swapuuids
+sfdiskPartitionFileName(/images/host name,2)=/images/host name/d2.partitions
+sfdiskLegacyOriginalPartitionFileName(/images/host name,2)=/images/host name/d2.original.partitions
+sfdiskMinimumPartitionFileName(/images/host name,2)=/images/host name/d2.minimum.partitions
+sfdiskOriginalPartitionFileName(/images/host name,2)=/images/host name/d2.partitions
+fixedSizePartitionsFileName(/images/host name,2)=/images/host name/d2.fixed_size_partitions
+hasGrubFileName(/images/host name,2)=/images/host name/d2.has_grub
+hasGrubFileName(/images/host name,2,sgdisk)=/images/host name/d2.grub.mbr
+EBRFileName(/images/host name,2,5)=/images/host name/d2p5.ebr
+EBRFileName(/images/host name,2,empty)=
+tmpEBRFileName(2,5)=/tmp/d2p5.ebr
+MBRFileName.up(/images/host name,2)=/images/host name/d2.mbr
+MBRFileName.up.sgdisk(/images/host name,2)=/images/host name/d2.mbr
+swapUUIDFileName(/mnt/img,10)=/mnt/img/d10.original.swapuuids
+sfdiskPartitionFileName(/mnt/img,10)=/mnt/img/d10.partitions
+sfdiskLegacyOriginalPartitionFileName(/mnt/img,10)=/mnt/img/d10.original.partitions
+sfdiskMinimumPartitionFileName(/mnt/img,10)=/mnt/img/d10.minimum.partitions
+sfdiskOriginalPartitionFileName(/mnt/img,10)=/mnt/img/d10.partitions
+fixedSizePartitionsFileName(/mnt/img,10)=/mnt/img/d10.fixed_size_partitions
+hasGrubFileName(/mnt/img,10)=/mnt/img/d10.has_grub
+hasGrubFileName(/mnt/img,10,sgdisk)=/mnt/img/d10.grub.mbr
+EBRFileName(/mnt/img,10,5)=/mnt/img/d10p5.ebr
+EBRFileName(/mnt/img,10,empty)=
+tmpEBRFileName(10,5)=/tmp/d10p5.ebr
+MBRFileName.up(/mnt/img,10)=/mnt/img/d10.mbr
+MBRFileName.up.sgdisk(/mnt/img,10)=/mnt/img/d10.mbr
+=== doInventory (dmidecode + base64 blocks) ===
+sysman=dmi[-s system-manufacturer]
+sysman64=ZG1pWy1zIHN5c3RlbS1tYW51ZmFjdHVyZXJdCg==
+sysproduct=dmi[-s system-product-name]
+sysproduct64=ZG1pWy1zIHN5c3RlbS1wcm9kdWN0LW5hbWVdCg==
+sysversion=dmi[-s system-version]
+sysversion64=ZG1pWy1zIHN5c3RlbS12ZXJzaW9uXQo=
+sysserial=dmi[-s system-serial-number]
+sysserial64=ZG1pWy1zIHN5c3RlbS1zZXJpYWwtbnVtYmVyXQo=
+sysuuid=dmi[-s system-uuid]
+sysuuid64=ZG1pWy1zIHN5c3RlbS11dWlkXQo=
+systype=
+systype64=Cg==
+biosversion=dmi[-s bios-version]
+biosversion64=ZG1pWy1zIGJpb3MtdmVyc2lvbl0K
+biosvendor=dmi[-s bios-vendor]
+biosvendor64=ZG1pWy1zIGJpb3MtdmVuZG9yXQo=
+biosdate=dmi[-s bios-release-date]
+biosdate64=ZG1pWy1zIGJpb3MtcmVsZWFzZS1kYXRlXQo=
+mbman=dmi[-s baseboard-manufacturer]
+mbman64=ZG1pWy1zIGJhc2Vib2FyZC1tYW51ZmFjdHVyZXJdCg==
+mbproductname=dmi[-s baseboard-product-name]
+mbproductname64=ZG1pWy1zIGJhc2Vib2FyZC1wcm9kdWN0LW5hbWVdCg==
+mbversion=dmi[-s baseboard-version]
+mbversion64=ZG1pWy1zIGJhc2Vib2FyZC12ZXJzaW9uXQo=
+mbserial=dmi[-s baseboard-serial-number]
+mbserial64=ZG1pWy1zIGJhc2Vib2FyZC1zZXJpYWwtbnVtYmVyXQo=
+mbasset=dmi[-s baseboard-asset-tag]
+mbasset64=ZG1pWy1zIGJhc2Vib2FyZC1hc3NldC10YWddCg==
+cpuman=dmi[-s processor-manufacturer]
+cpuman64=ZG1pWy1zIHByb2Nlc3Nvci1tYW51ZmFjdHVyZXJdCg==
+cpuversion=dmi[-s processor-version]
+cpuversion64=ZG1pWy1zIHByb2Nlc3Nvci12ZXJzaW9uXQo=
+cpucurrent=
+cpucurrent64=Cg==
+cpumax=
+cpumax64=Cg==
+mem=MemTotal:       16384000 kB
+mem64=TWVtVG90YWw6IDE2Mzg0MDAwIGtCCg==
+hdinfo= Model=STUBDISK, FwRev=1.0, SerialNo=SN123
+hdinfo64=TW9kZWw9U1RVQkRJU0ssIEZ3UmV2PTEuMCwgU2VyaWFsTm89U04xMjMK
+caseman=dmi[-s chassis-manufacturer]
+caseman64=ZG1pWy1zIGNoYXNzaXMtbWFudWZhY3R1cmVyXQo=
+casever=dmi[-s chassis-version]
+casever64=ZG1pWy1zIGNoYXNzaXMtdmVyc2lvbl0K
+caseserial=dmi[-s chassis-serial-number]
+caseserial64=ZG1pWy1zIGNoYXNzaXMtc2VyaWFsLW51bWJlcl0K
+caseasset=dmi[-s chassis-asset-tag]
+caseasset64=ZG1pWy1zIGNoYXNzaXMtYXNzZXQtdGFnXQo=
+inventory_graphics_vendor=StubVendor
+inventory_graphics_vendor64=U3R1YlZlbmRvcgo=
+inventory_graphics_product=StubGPU
+inventory_graphics_product64=U3R1YkdQVQo=
+=== changeHostname EOFREG ===
+ed \ControlSet001\Services\Tcpip\Parameters\NV Hostname
+GOLDENHOST
+ed \ControlSet001\Services\Tcpip\Parameters\Hostname
+GOLDENHOST
+ed \ControlSet001\Services\Tcpip\Parameters\NV HostName
+GOLDENHOST
+ed \ControlSet001\Services\Tcpip\Parameters\HostName
+GOLDENHOST
+ed \ControlSet001\Control\ComputerName\ActiveComputerName\ComputerName
+GOLDENHOST
+ed \ControlSet001\Control\ComputerName\ComputerName\ComputerName
+GOLDENHOST
+ed \ControlSet001\services\Tcpip\Parameters\NV Hostname
+GOLDENHOST
+ed \ControlSet001\services\Tcpip\Parameters\Hostname
+GOLDENHOST
+ed \ControlSet001\services\Tcpip\Parameters\NV HostName
+GOLDENHOST
+ed \ControlSet001\services\Tcpip\Parameters\HostName
+GOLDENHOST
+ed \CurrentControlSet\Services\Tcpip\Parameters\NV Hostname
+GOLDENHOST
+ed \CurrentControlSet\Services\Tcpip\Parameters\Hostname
+GOLDENHOST
+ed \CurrentControlSet\Services\Tcpip\Parameters\NV HostName
+GOLDENHOST
+ed \CurrentControlSet\Services\Tcpip\Parameters\HostName
+GOLDENHOST
+ed \CurrentControlSet\Control\ComputerName\ActiveComputerName\ComputerName
+GOLDENHOST
+ed \CurrentControlSet\Control\ComputerName\ComputerName\ComputerName
+GOLDENHOST
+ed \CurrentControlSet\services\Tcpip\Parameters\NV Hostname
+GOLDENHOST
+ed \CurrentControlSet\services\Tcpip\Parameters\Hostname
+GOLDENHOST
+ed \CurrentControlSet\services\Tcpip\Parameters\NV HostName
+GOLDENHOST
+ed \CurrentControlSet\services\Tcpip\Parameters\HostName
+GOLDENHOST
+q
+y
+

--- a/tests/golden/run.sh
+++ b/tests/golden/run.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# Golden-output differential harness for the FOS shared libraries.
+#
+# It drives the deterministic, refactor-targeted functions in funcs.sh over a
+# fixed battery of inputs and emits one canonical output stream. The point is to
+# prove that the DRY refactors in later commits change no observable output:
+#
+#   tests/golden/run.sh capture   # write fixtures/golden.txt (run BEFORE a refactor)
+#   tests/golden/run.sh check     # regenerate and diff against the committed fixture
+#   tests/golden/run.sh print     # just dump the current output to stdout
+#
+# Covered (per the DRY plan):
+#   - every *FileName() output string
+#   - the doInventory dmidecode block and the base64 encode block
+#   - the changeHostname registry EOFREG file contents
+#
+# This harness lives OUTSIDE rootfs_overlay, so it never enters the init.
+#
+# Mechanism: funcs.sh hardcodes /usr/share/fog/lib paths and calls hardware
+# tools. We copy the library into a temp sandbox with those absolute paths
+# rewritten, stub the external tools deterministically, then source and call the
+# real functions. Baseline and candidate runs execute on the same host with the
+# same stubs, so any host-specific value (e.g. /proc/meminfo) cancels out.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_LIB="$HERE/../../Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib"
+FIXTURE="$HERE/fixtures/golden.txt"
+
+[[ -f $REPO_LIB/funcs.sh ]] || { echo "ERROR: cannot find funcs.sh under $REPO_LIB" >&2; exit 2; }
+
+# Emit the canonical golden stream to stdout. Runs entirely in a subshell so the
+# sandbox, stubs and sourced globals never leak back to the caller.
+generate() (
+    set +u
+    local SANDBOX STUBBIN
+    SANDBOX="$(mktemp -d)"
+    trap 'rm -rf "$SANDBOX"' EXIT
+    STUBBIN="$SANDBOX/bin"
+    mkdir -p "$STUBBIN"
+
+    # --- sandbox copy of the library with host-absolute paths rewritten ---
+    cp "$REPO_LIB/partition-funcs.sh" "$SANDBOX/partition-funcs.sh"
+    # Fixed meminfo so the inventory 'mem' line is machine-independent.
+    printf 'MemTotal:       16384000 kB\n' > "$SANDBOX/meminfo"
+    sed -e "s#^\. /usr/share/fog/lib/partition-funcs\.sh#. $SANDBOX/partition-funcs.sh#" \
+        -e "s#/usr/share/fog/lib/EOFREG#$SANDBOX/EOFREG#g" \
+        -e "s#/proc/meminfo#$SANDBOX/meminfo#g" \
+        "$REPO_LIB/funcs.sh" > "$SANDBOX/funcs.sh"
+
+    # --- deterministic stubs for external executables (via PATH) ---
+    mkstub() { printf '#!/bin/bash\n%s\n' "$2" > "$STUBBIN/$1"; chmod +x "$STUBBIN/$1"; }
+    mkstub dmidecode 'echo "dmi[$*]"'
+    mkstub hdparm 'echo " Model=STUBDISK, FwRev=1.0, SerialNo=SN123"'
+    mkstub smartctl 'exit 0'
+    mkstub lshw 'echo "[{\"vendor\":\"StubVendor\",\"product\":\"StubGPU\"}]"'
+    mkstub ntfs-3g 'exit 0'
+    mkstub umount 'exit 0'
+    mkstub mkdir 'exit 0'
+    mkstub reged "cp '$SANDBOX/EOFREG' '$SANDBOX/EOFREG.captured' 2>/dev/null; exit 0"
+    PATH="$STUBBIN:$PATH"
+
+    # --- stubs for the library's own helpers we don't want to execute ---
+    handleError() { echo "HANDLEERROR: $*"; }
+    handleWarning() { echo "HANDLEWARNING: $*"; }
+    debugPause() { :; }
+    dots() { :; }
+    hasGRUB() { hasGRUB=0; }
+
+    # shellcheck disable=SC1090
+    . "$SANDBOX/funcs.sh"
+
+    # ============================================================
+    echo "=== FileName helpers ==="
+    local ip dn
+    for pair in "/net/dev/foo:1" "/images/host name:2" "/mnt/img:10"; do
+        ip="${pair%:*}"; dn="${pair##*:}"
+        swapUUIDFileName "$ip" "$dn"
+        echo "swapUUIDFileName($ip,$dn)=$swapuuidfilename"
+        sfdiskPartitionFileName "$ip" "$dn"
+        echo "sfdiskPartitionFileName($ip,$dn)=$sfdiskoriginalpartitionfilename"
+        sfdiskLegacyOriginalPartitionFileName "$ip" "$dn"
+        echo "sfdiskLegacyOriginalPartitionFileName($ip,$dn)=$sfdisklegacyoriginalpartitionfilename"
+        sfdiskMinimumPartitionFileName "$ip" "$dn"
+        echo "sfdiskMinimumPartitionFileName($ip,$dn)=$sfdiskminimumpartitionfilename"
+        sfdiskOriginalPartitionFileName "$ip" "$dn"
+        echo "sfdiskOriginalPartitionFileName($ip,$dn)=$sfdiskoriginalpartitionfilename"
+        fixedSizePartitionsFileName "$ip" "$dn"
+        echo "fixedSizePartitionsFileName($ip,$dn)=$fixed_size_file"
+        hasGrubFileName "$ip" "$dn"
+        echo "hasGrubFileName($ip,$dn)=$hasgrubfilename"
+        hasGrubFileName "$ip" "$dn" sgdisk
+        echo "hasGrubFileName($ip,$dn,sgdisk)=$hasgrubfilename"
+        EBRFileName "$ip" "$dn" 5
+        echo "EBRFileName($ip,$dn,5)=$ebrfilename"
+        EBRFileName "$ip" "$dn" ""
+        echo "EBRFileName($ip,$dn,empty)=$ebrfilename"
+        tmpEBRFileName "$dn" 5
+        echo "tmpEBRFileName($dn,5)=$tmpebrfilename"
+        type=up; mbrout=""
+        MBRFileName "$ip" "$dn" mbrout
+        echo "MBRFileName.up($ip,$dn)=$mbrout"
+        type=up; mbrout=""
+        MBRFileName "$ip" "$dn" mbrout sgdisk
+        echo "MBRFileName.up.sgdisk($ip,$dn)=$mbrout"
+    done
+
+    # ============================================================
+    echo "=== doInventory (dmidecode + base64 blocks) ==="
+    hd="/dev/stubdisk"
+    doInventory
+    local v n64
+    for v in sysman sysproduct sysversion sysserial sysuuid systype biosversion \
+             biosvendor biosdate mbman mbproductname mbversion mbserial mbasset \
+             cpuman cpuversion cpucurrent cpumax mem hdinfo caseman casever \
+             caseserial caseasset \
+             inventory_graphics_vendor inventory_graphics_product; do
+        n64="${v}64"
+        echo "$v=${!v}"
+        echo "${v}64=${!n64}"
+    done
+
+    # ============================================================
+    echo "=== changeHostname EOFREG ==="
+    REG_LOCAL_MACHINE_7="$SANDBOX/regfile"
+    : > "$SANDBOX/regfile"
+    hostname="GOLDENHOST"
+    hostearly=1
+    osid=2
+    changeHostname "/dev/stubpart" >/dev/null 2>&1
+    if [[ -f $SANDBOX/EOFREG.captured ]]; then
+        cat "$SANDBOX/EOFREG.captured"
+    else
+        echo "EOFREG NOT CAPTURED"
+    fi
+)
+
+mode="${1:-print}"
+case "$mode" in
+    print)
+        generate
+        ;;
+    capture)
+        mkdir -p "$(dirname "$FIXTURE")"
+        generate > "$FIXTURE"
+        echo "Captured golden fixture -> $FIXTURE ($(wc -l < "$FIXTURE") lines)"
+        ;;
+    check)
+        [[ -f $FIXTURE ]] || { echo "ERROR: no fixture at $FIXTURE (run 'capture' first)" >&2; exit 2; }
+        tmp="$(mktemp)"
+        generate > "$tmp"
+        if diff -u "$FIXTURE" "$tmp"; then
+            echo "OK: output is byte-identical to the golden fixture."
+            rm -f "$tmp"
+        else
+            echo "FAIL: output differs from the golden fixture (see diff above)." >&2
+            rm -f "$tmp"
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Usage: $0 {capture|check|print}" >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
## Summary

DRY refactor of the FOS init libraries (`funcs.sh`, `partition-funcs.sh`) plus the
supporting build/release tooling and a golden-output test harness. The headline
change is a `checkStatus` result-handler that replaces ~25 hand-rolled
`...Done`/`...Failed` status sites with a single helper.

Commits:
- `1a91e4f` FOS: dedup build/release host tooling (DRY)
- `3c8f014` FOS: add golden-output differential test harness
- `85e8138` FOS: dedup inventory/registry/FileName helpers in funcs.sh
- `6bed79e` FOS: add checkStatus result-handler and roll out to 25 status sites

## Validation — real-hardware field test (no behavior change)

The offline golden harness proves byte-identical string/file output, but the status
handler's **execution paths on real disks had never run**. To close that gap I built
two inits that differ **only** by these two libraries — `init_master.xz` (baseline)
and `init_dryrefactor.xz` (candidate) — by loop-mounting production `init.xz` and
swapping the libs, repacked with `xz --check=crc32`. Production `init.xz` was never
modified. Each init ran a full **capture → deploy** round-trip on real VMs with the
FOS console logged over a VirtualBox serial UART, then the A-vs-B console output was
diffed (interpreted: ignoring durations / progress % / device-instance values).

- **Capture:** 89/89 status lines identical. The only 4 diffs are environmental
  (server `/images` fill between runs, a one-time sgdisk `0xEE` auto-repair done by
  the first run, NTFS resize size shifting because Windows ran between captures) —
  none implicate the refactored code. Verified the refactor does **not** suppress
  stderr (a benign "Reg file not found" leaks identically under both inits).
- **Deploy:** 58/58 status lines **byte-identical**, including all partition-type
  GUIDs and restored UUIDs (deterministic from the stored image).
- **Functional gate:** the refactor-deployed VM boots cleanly into Windows.

Conclusion: the refactor produces identical runtime behavior on real disks across
capture and deploy. Field test **passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
