### PR TITLE
build.sh: fail on source-download errors; fetch kernel from cdn.kernel.org

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -170,6 +170,8 @@ function buildFilesystem() {
     if [[ $fsDownloadOnly == "y" ]]; then
         echo "Downloading Buildroot source packages for $arch ..."
         make source
+        status=$?
+        [[ $status -gt 0 ]] && echo "Failed to download source packages for $arch." && exit $status
         cd ..
         echo "$arch filesystem packages downloaded. Exiting."
         return 0
@@ -234,7 +236,7 @@ function buildKernel() {
     kflags=$(makeFlags "$arch" kernel)
     ktarget=bzImage
     [[ $arch == arm64 ]] && ktarget=Image
-    kernelURL="https://www.kernel.org/pub/linux/kernel/v${KERNEL_VERSION:0:1}.x/linux-$KERNEL_VERSION.tar.xz"
+    kernelURL="https://cdn.kernel.org/pub/linux/kernel/v${KERNEL_VERSION:0:1}.x/linux-$KERNEL_VERSION.tar.xz"
     echo "Preparing kernel $KERNEL_VERSION on $arch build:"
     [[ -d kernelsource$arch ]] && rm -rf "kernelsource$arch"
     if [[ ! -f linux-$KERNEL_VERSION.tar.xz ]]; then

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -25,6 +25,7 @@ declare -ar common_dependencies=(
     "bzip2"
     "findutils"
     "autoconf"
+    "automake"
     "libtool"
 )
 

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -26,7 +26,6 @@ declare -ar common_dependencies=(
     "findutils"
     "autoconf"
     "libtool"
-    "autopoint"
 )
 
 declare -ar deb_dependencies=(
@@ -34,6 +33,7 @@ declare -ar deb_dependencies=(
     "xz-utils"
     "g++"
     "libncurses-dev"
+    "autopoint"
 )
 
 declare -ar rhel_dependencies=(
@@ -42,6 +42,7 @@ declare -ar rhel_dependencies=(
     "xz"
     "gcc-c++"
     "ncurses-devel"
+    "gettext-devel"
 )
 
 

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -64,15 +64,15 @@ function checkDependencies() {
         "debian" | "ubuntu")
             dependencies=("${common_dependencies[@]}" "${deb_dependencies[@]}")
             package_manager="sudo apt install -y"
-            pkgmgr() {
-                dpkg -l
+            pkginstalled() {
+                dpkg -s "$1" 2> /dev/null | grep -q "^Status:.*ok installed"
             }
             ;;
         "rhel" | "rocky" | "fedora")
             dependencies=("${common_dependencies[@]}" "${rhel_dependencies[@]}")
             package_manager="sudo dnf install -y"
-            pkgmgr() {
-                rpm -qa --qf "ii %{NAME}\n"
+            pkginstalled() {
+                rpm -q --whatprovides "$1" > /dev/null 2>&1
             }
             if [[ $running_os == "rhel" || $running_os == "rocky" ]]; then
                 __epel_repo_message
@@ -87,8 +87,7 @@ function checkDependencies() {
 
     missing_packages=""
     for package in "${dependencies[@]}"; do
-        pkgmgr | awk '{print $2}' | cut -d':' -f1 | grep -qe "${package}"
-        if [[ $? -ne 0 ]]; then
+        if ! pkginstalled "${package}"; then
             missing_packages="${missing_packages} ${package}"
         fi
     done


### PR DESCRIPTION
## What happened today

CI run 28741856230 (kernel-6.18 experimental) failed in a way worth fixing at the root:

1. kernel.org's `www.kernel.org` frontend started timing out. Buildroot's internal wget (`--tries=2 --timeout=10`) gave up, and its fallback mirror `sources.buildroot.net` returned 404 (it only mirrors kernel versions pinned in Buildroot's own hash files, so a custom `6.18.38` headers version isn't there).
2. `./build.sh -i --fs-download-only` ran `make source` for all three arches, **all three failed to download `linux-6.18.38.tar.xz` — and the job still exited 0**, because the exit status of `make source` was never checked. The half-empty dl directory got saved into the Actions cache, and all three `build_initrd_*` jobs then failed on the same download.

## Changes

- **Propagate `make source` failures** in `--fs-download-only` mode, using the same `status`/`exit` pattern the script already uses for the main build. A failed download job now fails visibly instead of poisoning the dl cache.
- **`kernelURL`: `www.kernel.org` → `cdn.kernel.org`.** The CDN is what kernel.org recommends for automated downloads and is also modern Buildroot's default `BR2_KERNEL_MIRROR`. (The kernel jobs on today's run survived only because build.sh's wget uses default retry settings — same fragile host, more patience.)
- **`dependencies.sh`: fix the dependency check on Fedora/RHEL.** The check greps installed *package names*, and `autopoint` is a Debian package name — on RHEL-family distros the binary ships inside `gettext-devel`, so the check always failed (and `--install-dep` tried `dnf install autopoint`, which doesn't exist). `autopoint` now lives in the Debian list and RHEL-family checks/installs `gettext-devel` instead. Also added `automake` to the list — partclone's `AUTORECONF = YES` configure step needs `aclocal` and fails without it. Both gaps were found doing a local build on Fedora 44; CI never hits them because Ubuntu runner images ship automake preinstalled and use apt package names.
- **`dependencies.sh`: query the package manager per package instead of grepping the installed-package list.** The old check was an unanchored grep over all installed package names, so any package *containing* a dependency's name satisfied it — on Fedora, `libtool-ltdl` passed the `libtool` check while `libtoolize` was actually missing (found the hard way: partclone's configure died mid-build). Anchoring the grep would break the other direction (`wget` on Fedora 40+ is provided by the package `wget2-wget`). The check now asks the package manager directly: `rpm -q --whatprovides` on RHEL-family (resolves virtual provides) and `dpkg -s` + installed-status on Debian-family. Verified against all 23 dependencies on Fedora 44: exactly the genuinely-missing package is flagged, no false positives or negatives.

The Buildroot-side counterpart (the fs configs carry a legacy `BR2_KERNEL_MIRROR="http://www.kernel.org/pub/"`) is fixed on the kernel-6.18 branch in 572c994; if this PR is wanted on master too I can cherry-pick that one-liner onto master separately.

Note: changing build.sh re-keys the `buildroot-dl-*` Actions cache (keyed on `hashFiles('**/build.sh')`); the prefix restore-key means the first run after merge restores the old cache and only downloads what's missing. I also deleted today's poisoned cache entry so it can't be restored again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
