### PR TITLE
Refuse deploy on logical-sector-size mismatch

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -2054,6 +2054,52 @@ clearPartitionTables() {
     runPartprobe "$disk"
     debugPause
 }
+# Refuses a deploy when the target disk's logical sector size does not match the
+# sector size the image was captured with. Partition-table LBA units and
+# filesystem metadata bake in the source disk's logical sector size at capture
+# and are not rewritten on restore, so a mismatch yields an unmountable/
+# unbootable result. The source size is read from the stored sfdisk dump's
+# "sector-size:" line and the target size comes from `blockdev --getss`; we only
+# refuse when both are known and differ. sfdisk did not emit "sector-size:"
+# until util-linux 2.35 (~2020), so an older dump (including a genuine 4Kn one)
+# records no source size; there we allow the deploy rather than guess 512 and
+# wrongly refuse a matching 4Kn->4Kn deploy that works today. See
+# docs/adr/0001-sector-size-geometry-match-or-refuse.md
+#
+# $1 is the disk (e.g. /dev/sda)
+# $2 is the disk number
+# $3 is the image path
+validateImageSectorSize() {
+    local disk="$1"
+    local disk_number="$2"
+    local imagePath="$3"
+    [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    [[ -z $disk_number ]] && handleError "No drive number passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    [[ -z $imagePath ]] && handleError "No image path passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    local targetsectorsize=$(blockdev --getss $disk 2>/dev/null)
+    # If the target size can't be read, don't introduce a new failure.
+    [[ -z $targetsectorsize ]] && return 0
+    local sfdiskminimumpartitionfilename=""
+    local sfdiskoriginalpartitionfilename=""
+    local sfdisklegacyoriginalpartitionfilename=""
+    sfdiskMinimumPartitionFileName "$imagePath" "$disk_number"
+    sfdiskPartitionFileName "$imagePath" "$disk_number"
+    sfdiskLegacyOriginalPartitionFileName "$imagePath" "$disk_number"
+    local sfdiskfilename=""
+    local candidate=""
+    for candidate in "$sfdiskminimumpartitionfilename" "$sfdiskoriginalpartitionfilename" "$sfdisklegacyoriginalpartitionfilename"; do
+        [[ -r $candidate ]] && sfdiskfilename="$candidate" && break
+    done
+    # The source size is only known if the dump recorded it. With no dump, or a
+    # pre-util-linux-2.35 dump that has no "sector-size:" line, the source size
+    # is unknown; allow the deploy rather than guess and risk a wrong refusal.
+    local imagesectorsize=""
+    [[ -n $sfdiskfilename ]] && imagesectorsize=$(awk '/^sector-size:/{print $2; exit}' "$sfdiskfilename")
+    [[ -z $imagesectorsize ]] && return 0
+    if [[ $imagesectorsize -ne $targetsectorsize ]]; then
+        handleError "Sector size mismatch (${FUNCNAME[0]})\n   Image was captured on a disk with ${imagesectorsize}-byte logical sectors, but $disk uses ${targetsectorsize}-byte logical sectors.\n   Partition-table and filesystem geometry cannot be translated between logical sector sizes, so this image cannot be deployed to this disk.\n   Deploy this image only to a disk with ${imagesectorsize}-byte logical sectors, or capture a new image on a disk with ${targetsectorsize}-byte logical sectors."
+    fi
+}
 # Restores the partition tables and boot loaders
 #
 # $1 is the disk
@@ -2079,6 +2125,7 @@ restorePartitionTablesAndBootLoaders() {
         debugPause
         return
     fi
+    validateImageSectorSize "$disk" "$disk_number" "$imagePath"
     clearPartitionTables "$disk"
     majorDebugEcho "Partition table should be empty now."
     majorDebugShowCurrentPartitionTable "$disk" "$disk_number"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,43 @@
+# FOS — Context Glossary
+
+A shared vocabulary for the FOS (FOG Operating System) imaging environment.
+Glossary only — no implementation details, no decisions. Decisions that are hard
+to reverse live in `docs/adr/`.
+
+## Sector geometry
+
+- **512n** — Drive with 512-byte *physical* and 512-byte *logical* sectors.
+  Legacy geometry. The OS issues 512-byte I/O.
+
+- **512e** — Drive with 4096-byte *physical* sectors but 512-byte *logical*
+  sectors (512-emulation). The overwhelming majority of "4K" SSDs/NVMe. The OS
+  still sees 512-byte logical sectors, so anything captured on 512n deploys onto
+  512e unchanged. For imaging purposes, 512e behaves as 512.
+
+- **4Kn** — Drive with 4096-byte *physical* and 4096-byte *logical* sectors
+  ("4K native"). The OS issues 4096-byte I/O and cannot do sub-4K logical
+  access. Rare: mostly enterprise SAS and NVMe reformatted to a 4K LBA format.
+
+- **Logical sector size** — The sector size the OS/filesystem sees and addresses
+  by. This is the number that matters for imaging: it is baked into partition
+  tables (LBA units) and filesystem metadata at capture time.
+
+- **LBA format (LBAF)** — On NVMe, a drive-supported sector-size mode. Many
+  NVMe drives expose both a 512-byte and a 4096-byte LBAF and can be switched
+  between them with `nvme format` (destructive). SATA drives generally cannot
+  change their logical sector size.
+
+## Imaging model
+
+- **Geometry mismatch** — The core problem: a captured image's partition table
+  (LBA units) and filesystem metadata (e.g. NTFS `$Boot` `bytes_per_sector`)
+  encode the *source drive's logical sector size*. Deploying onto a target with a
+  different logical sector size produces a filesystem whose declared geometry
+  contradicts the device, so the OS will not mount/boot. Applies in both
+  directions (512→4Kn and 4Kn→512).
+
+- **partclone image** — FOG's filesystem-aware capture format for supported
+  filesystems (NTFS, ext, etc.). Stores used blocks plus the filesystem's own
+  metadata. It restores the filesystem verbatim; it does **not** rewrite the
+  filesystem's sector/cluster geometry, which is why geometry mismatch is not
+  fixed by the restore path.

--- a/docs/adr/0001-sector-size-geometry-match-or-refuse.md
+++ b/docs/adr/0001-sector-size-geometry-match-or-refuse.md
@@ -1,0 +1,62 @@
+# Refuse a deploy on logical-sector-size mismatch instead of translating
+
+A captured image bakes in the source disk's **logical sector size**: the
+partition table stores offsets and sizes in LBA units of that size, and each
+captured filesystem records it in its own metadata (e.g. NTFS `$Boot`
+`bytes_per_sector`). partclone restores a filesystem verbatim and does not
+rewrite that geometry, so deploying a 512-byte-logical image onto a
+4096-byte-logical disk (or the reverse) produces a partition table and
+filesystems whose declared geometry contradicts the device — unmountable and
+unbootable. We decided FOS will **detect the mismatch and refuse the deploy with
+an actionable message** rather than attempt to translate geometry on the fly.
+
+## Why not translate
+
+Rewriting LBA units in the partition table is only the surface of it. Every
+bootable filesystem would also need its internal geometry rewritten
+consistently, bootloaders re-pointed, and any embedded absolute sector
+references fixed up — per filesystem, per OS. That is not something partclone
+does or that we can do reliably for an arbitrary captured image. A deploy that
+"succeeds" but silently produces an unbootable disk is worse than a clean
+refusal, so we refuse.
+
+The eventual answer for the tractable case (NVMe drives that expose both a 512-
+and a 4096-byte LBA format) is to reformat the *target* to match the image's
+sector size with `nvme format` before deploying — matching geometry rather than
+translating it. That is deliberately **out of scope here** and left to a later
+branch; this change is the safety net that must land first.
+
+## How it works
+
+`validateImageSectorSize()` (in `funcs.sh`) runs once per target disk inside
+`restorePartitionTablesAndBootLoaders()`, after the `nombr` skip and before the
+first destructive write (`clearPartitionTables`). It compares the target's
+logical sector size (`blockdev --getss`) against the size recorded in the stored
+sfdisk dump's `sector-size:` line (checked in the same
+minimum → original → legacy precedence the restore path uses). It refuses **only
+when both sizes are known and differ**, calling the existing fatal
+`handleError`. If either side is unknown — `blockdev` can't read the target, or
+the dump records no source size — it returns without erroring, so it never
+introduces a new failure on a path that works today.
+
+## Known gaps (deliberate)
+
+This is a safety net, not full coverage. It hooks the partition-table restore
+path only, so these cases are **not** guarded:
+
+- **Raw `dd` whole-disk images (`imgType=dd`).** dd capture stores no source
+  geometry at all, so a mismatch cannot be detected without adding new
+  capture-side metadata. Out of scope here.
+- **Single-partition / `nombr` restores.** These intentionally skip the
+  partition-table rewrite (and therefore this check) because they restore into a
+  table the operator already laid down.
+- **Images captured before util-linux 2.35 (~2020).** `sfdisk -d` did not emit
+  the `sector-size:` line until then, so an older dump — including a genuine 4Kn
+  one — records no source size and cannot be checked. We allow rather than guess:
+  guessing 512 would wrongly refuse a matching 4Kn→4Kn deploy that works today.
+  Every image FOS has produced for years carries the line, so this only affects
+  images captured by long-obsolete FOS releases.
+
+These gaps are acceptable for a first cut: the common, high-value case
+(deploying a resizable or multi-partition image onto a whole disk) is covered,
+and the refusal is honest about what it protects.

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,3 +25,18 @@ tools stubbed deterministically. The fixture is therefore machine-independent.
 
 Workflow for a refactor: run `check` on a clean tree (should pass against the
 committed fixture), make the change, run `check` again — it must still pass.
+
+## checks/ — assertion harnesses
+
+Pass/fail assertions for behaviour that a single golden output stream can't
+express (e.g. "does this function abort or not?"). Each script runs a battery of
+cases and exits non-zero if any fail.
+
+```sh
+tests/checks/sector-size.sh   # validateImageSectorSize() refuses on a
+                              # logical-sector-size mismatch, allows on match
+```
+
+Like the golden harness, these source a sandbox copy of the library with its
+hardcoded paths rewritten and the external tools stubbed, so they run on any
+host without hardware.

--- a/tests/checks/sector-size.sh
+++ b/tests/checks/sector-size.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+#
+# Assertion harness for validateImageSectorSize() in funcs.sh.
+#
+#   tests/checks/sector-size.sh        # run all cases, exit non-zero on any failure
+#
+# validateImageSectorSize() refuses a deploy when the target disk's logical
+# sector size (blockdev --getss) does not match the size recorded in the stored
+# sfdisk dump's "sector-size:" line. A single golden output stream can't express
+# a pass/fail (abort vs no-op) assertion, so this is a sibling to the golden
+# harness rather than a case inside it.
+#
+# Mechanism mirrors tests/golden/run.sh: source a sandbox copy of the library
+# with its hardcoded /usr/share/fog/lib paths rewritten, and PATH-shadow the
+# external tools (here, blockdev) with deterministic stubs. handleError is the
+# real fatal function until we source it; we override it AFTER sourcing so a
+# refusal is observable instead of exiting the test.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_LIB="$HERE/../../Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib"
+
+[[ -f $REPO_LIB/funcs.sh ]] || { echo "ERROR: cannot find funcs.sh under $REPO_LIB" >&2; exit 2; }
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# --- sandbox copy of the library with host-absolute paths rewritten ---
+cp "$REPO_LIB/partition-funcs.sh" "$SANDBOX/partition-funcs.sh"
+sed -e "s#^\. /usr/share/fog/lib/partition-funcs\.sh#. $SANDBOX/partition-funcs.sh#" \
+    "$REPO_LIB/funcs.sh" > "$SANDBOX/funcs.sh"
+
+# --- deterministic stub for blockdev (--getss echoes $FAKE_SS) ---
+STUBBIN="$SANDBOX/bin"
+mkdir -p "$STUBBIN"
+cat > "$STUBBIN/blockdev" <<'EOF'
+#!/bin/bash
+# Only --getss is used by validateImageSectorSize. Echo the configured size;
+# an empty FAKE_SS emulates blockdev failing to read the target.
+[[ "$1" == "--getss" ]] && printf '%s\n' "$FAKE_SS"
+exit 0
+EOF
+chmod +x "$STUBBIN/blockdev"
+
+# Write a minimal but realistic sfdisk -d dump into $1. If $2 is non-empty it is
+# used as the sector-size value; if empty, the sector-size line is omitted (as a
+# legacy pre-sector-size sfdisk dump would be).
+write_dump() {
+    local file="$1" ss="$2"
+    {
+        echo "label: gpt"
+        echo "device: /dev/sdb"
+        echo "unit: sectors"
+        echo "first-lba: 34"
+        [[ -n $ss ]] && echo "sector-size: $ss"
+        echo ""
+        echo "/dev/sdb1 : start=        2048, size=     2048000, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4"
+    } > "$file"
+}
+
+PASS=0
+FAIL=0
+
+# run_case <name> <target_ss> <expect: abort|noabort> -- then the caller has
+# already populated $IMGDIR with the dump file(s) for this case.
+run_case() {
+    local name="$1" target_ss="$2" expect="$3"
+    local out got
+    out="$(
+        set +u
+        export PATH="$STUBBIN:$PATH"
+        export FAKE_SS="$target_ss"
+        . "$SANDBOX/funcs.sh"
+        # Override AFTER sourcing so the real fatal handleError doesn't exit us.
+        handleError() { echo "ABORT: $*"; }
+        validateImageSectorSize "/dev/sdb" "1" "$IMGDIR"
+        echo "RETURNED"
+    )"
+    if [[ $out == *"ABORT:"* ]]; then got="abort"; else got="noabort"; fi
+    if [[ $got == "$expect" ]]; then
+        echo "PASS: $name (expected $expect)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $name (expected $expect, got $got)"
+        echo "      output: $(printf '%s' "$out" | tr '\n' '|')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Each case gets a fresh image dir so leftover dumps can't cross-contaminate.
+new_imgdir() { IMGDIR="$SANDBOX/img.$1"; rm -rf "$IMGDIR"; mkdir -p "$IMGDIR"; }
+
+# 1. Match: 512 image onto 512 disk -> allow.
+new_imgdir 1; write_dump "$IMGDIR/d1.minimum.partitions" 512
+run_case "match 512->512" 512 noabort
+
+# 2. Mismatch: 4Kn image onto 512 disk -> refuse.
+new_imgdir 2; write_dump "$IMGDIR/d1.minimum.partitions" 4096
+run_case "mismatch 4096-image -> 512-disk" 512 abort
+
+# 3. Mismatch other direction: 512 image onto 4Kn disk -> refuse.
+new_imgdir 3; write_dump "$IMGDIR/d1.minimum.partitions" 512
+run_case "mismatch 512-image -> 4096-disk" 4096 abort
+
+# 4. No dump at all (dd-style / missing metadata): source unknown -> allow.
+new_imgdir 4
+run_case "no dump -> source unknown -> allow" 512 noabort
+
+# 5. Dump present but no sector-size line (pre-util-linux-2.35 sfdisk): source
+# unknown -> allow, even though the target is 512.
+new_imgdir 5; write_dump "$IMGDIR/d1.minimum.partitions" ""
+run_case "dump without sector-size -> source unknown -> allow" 512 noabort
+
+# 6. blockdev can't read the target size: never introduce a new failure -> allow.
+new_imgdir 6; write_dump "$IMGDIR/d1.minimum.partitions" 4096
+run_case "unreadable target sector size -> no-op" "" noabort
+
+# 7. Precedence: minimum (4096) must win over original (512). Target 4096 -> allow.
+new_imgdir 7
+write_dump "$IMGDIR/d1.partitions" 512
+write_dump "$IMGDIR/d1.minimum.partitions" 4096
+run_case "minimum file wins over original" 4096 noabort
+
+# 8. Legacy fallback: only the legacy original file exists (4096) onto 512 -> refuse.
+new_imgdir 8; write_dump "$IMGDIR/d1.original.partitions" 4096
+run_case "legacy original file is read" 512 abort
+
+# 9. A pre-util-linux-2.35 4Kn image (dump has no sector-size line) onto a 4Kn
+# target must NOT be refused: guessing 512 would wrongly block a deploy that
+# works. Source unknown -> allow. (Guards against the default-512 regression.)
+new_imgdir 9; write_dump "$IMGDIR/d1.minimum.partitions" ""
+run_case "no sector-size line -> allow onto 4096-disk" 4096 noabort
+
+# 10. Middle precedence tier exercised alone: d<N>.partitions is the only dump
+# (the standard case for a non-resizable image). 4096 image onto 512 -> refuse.
+new_imgdir 10; write_dump "$IMGDIR/d1.partitions" 4096
+run_case "d<N>.partitions is read when it is the only dump" 512 abort
+
+echo "----"
+echo "$PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## What

Adds a safety net that **refuses a deploy when the target disk's logical sector size does not match the sector size the image was captured with**, instead of silently producing an unmountable/unbootable disk.

A captured image bakes in the source disk's logical sector size — the partition table stores LBA units of that size and each filesystem records it in its own metadata. partclone restores geometry verbatim, so deploying a 4Kn image onto a 512-byte-logical disk (or the reverse) can never boot. Today that fails silently, late, and confusingly; this makes it fail early with an actionable message.

## How

`validateImageSectorSize()` runs once per target disk inside `restorePartitionTablesAndBootLoaders()`, after the `nombr` skip and before the first destructive write (`clearPartitionTables`). It compares `blockdev --getss` on the target against the stored sfdisk dump's `sector-size:` line (minimum → original → legacy precedence) and calls the existing fatal `handleError` on mismatch.

It refuses **only when both sizes are known and differ**. If `blockdev` can't read the target, or the dump records no source size, it returns without erroring — so no path that works today gains a new failure. (`sfdisk` did not emit `sector-size:` until util-linux 2.35 (~2020); a genuine 4Kn image captured by an older FOS has no recorded source size, and guessing 512 there would wrongly refuse a matching 4Kn→4Kn deploy, so we allow instead.)

## Scope / known gaps (documented in the ADR)

This is the safety net only. Reformatting an NVMe target to match the image's sector size (`nvme format` / LBAF) is **deferred to a later branch**. Not guarded here: raw `dd` whole-disk images (store no source geometry), single-partition/`nombr` restores (intentionally skip the table rewrite), and pre-util-linux-2.35 images (no recorded source size).

## Verification

- `tests/checks/sector-size.sh`: 10/10 pass (match/mismatch both directions, precedence tiers, unreadable target, unknown-source allow, middle-tier-alone, pre-2.35-4Kn-onto-4Kn allow). Each new case mutation-tested to confirm it fails if its defect is reintroduced.
- `tests/golden/run.sh check`: byte-identical (no change to existing library output).
- `bash -n` clean.

## Files
- `funcs.sh`: `validateImageSectorSize()` + call site
- `docs/adr/0001-...`: why we refuse rather than translate, and the known gaps
- `CONTEXT.md`: sector-geometry glossary
- `tests/checks/sector-size.sh`, `tests/README.md`: assertion harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)