### PR TITLE
CI: make experimental release tags unique per run, not per day

### DIFF
--- a/.github/workflows/create_experimental_release.yml
+++ b/.github/workflows/create_experimental_release.yml
@@ -330,11 +330,11 @@ jobs:
 
       - name: Set release name variable
         run: |
-          echo "RELEASE_NAME=Experimental release from $(date '+%Y-%m-%d')" >> $GITHUB_ENV
+          echo "RELEASE_NAME=Experimental release from $(date -u '+%Y-%m-%d %H:%M UTC')" >> $GITHUB_ENV
 
       - name: Set tag name variable
         run: |
-          echo "TAG_NAME=EXP_$(date '+%Y%m%d')" >> $GITHUB_ENV
+          echo "TAG_NAME=EXP_$(date -u '+%Y%m%d-%H%M%S')" >> $GITHUB_ENV
 
       - name: Get Linux Kernel version from build.sh
         run: |


### PR DESCRIPTION
## What

The experimental-release workflow tagged releases with a **date-only** tag (`EXP_%Y%m%d`) and a date-only release name. A second experimental release on the same day collides with the existing tag, so only one experimental release can exist per day.

## How

Tag now includes the time to the second (`EXP_%Y%m%d-%H%M%S`), and the release name includes `HH:MM UTC`. Multiple experimental releases per day no longer collide.

CI-only change; no imaging code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)