### PR TITLE
Match target geometry to the image on sector-size mismatch; harden the fill engine

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -2054,6 +2054,63 @@ clearPartitionTables() {
     runPartprobe "$disk"
     debugPause
 }
+# Low-level reformats an NVMe namespace to a target logical sector size when the
+# device exposes a matching LBA format, so an image captured at that sector size
+# can deploy to it. Returns 0 only after the reformat is confirmed to have taken
+# effect; returns non-zero (leaving the disk untouched) for a non-NVMe device, a
+# device with no matching metadata-free LBA format, or any reformat failure, so
+# the caller can fall back to refusing the deploy.
+#
+# $1 is the disk (e.g. /dev/nvme0n1)
+# $2 is the wanted logical sector size in bytes (the image's sector size)
+nvmeReformatToSectorSize() {
+    local disk="$1"
+    local wantsize="$2"
+    [[ $disk == *[Nn][Vv][Mm][Ee]* ]] || return 1
+    # `nvme id-ns` prints one line per LBA format, e.g.
+    #   lbaf  1 : ms:0   lbads:12 rp:0x2 (in use)
+    # where the logical block size is 2^lbads bytes. Pick the first metadata-free
+    # (ms:0) format whose size equals the image's sector size.
+    local lbaf=$(nvme id-ns "$disk" 2>/dev/null | awk -v want="$wantsize" '
+        $1 == "lbaf" {
+            idx = $2; sub(/:$/, "", idx); ms = ""; lbads = ""
+            for (i = 3; i <= NF; i++) {
+                if ($i ~ /^ms:/)    ms = substr($i, 4)
+                if ($i ~ /^lbads:/) lbads = substr($i, 7)
+            }
+            if (ms == 0 && lbads != "" && 2 ^ lbads == want) { print idx; exit }
+        }')
+    [[ -z $lbaf ]] && return 1
+    echo ""
+    echo " *** Logical sector-size mismatch on $disk ***"
+    echo "   This image was captured with ${wantsize}-byte logical sectors."
+    echo "   $disk is an NVMe device that exposes a matching ${wantsize}-byte LBA format (lbaf $lbaf)."
+    echo "   FOS will LOW-LEVEL REFORMAT this namespace to ${wantsize}-byte sectors so the image can deploy."
+    echo "   This ERASES the drive (the deploy would erase it regardless) and cannot be undone."
+    echo ""
+    echo " You have 60 seconds to power off this computer to cancel!"
+    local s=""
+    for ((s = 60; s > 0; s--)); do
+        printf "\r   Reformatting %s in %2d second(s)...  " "$disk" "$s"
+        usleep 1000000
+    done
+    printf "\n"
+    dots "Reformatting $disk to ${wantsize}-byte sectors"
+    nvme format "$disk" --lbaf="$lbaf" --force >/dev/null 2>&1
+    local fmtexit=$?
+    if [[ $fmtexit -ne 0 ]]; then
+        echo "Failed"
+        return 1
+    fi
+    runPartprobe "$disk"
+    local newsize=$(blockdev --getss "$disk" 2>/dev/null)
+    if [[ $newsize -ne $wantsize ]]; then
+        echo "Failed"
+        return 1
+    fi
+    echo "Done"
+    return 0
+}
 # Refuses a deploy when the target disk's logical sector size does not match the
 # sector size the image was captured with. Partition-table LBA units and
 # filesystem metadata bake in the source disk's logical sector size at capture
@@ -2065,6 +2122,11 @@ clearPartitionTables() {
 # records no source size; there we allow the deploy rather than guess 512 and
 # wrongly refuse a matching 4Kn->4Kn deploy that works today. See
 # docs/adr/0001-sector-size-geometry-match-or-refuse.md
+#
+# When both sizes are known and differ, we first try to make the target match by
+# low-level reformatting an NVMe namespace to the image's sector size
+# (nvmeReformatToSectorSize); only if that is impossible do we refuse. See
+# docs/adr/0002-nvme-reformat-target-to-match-image.md
 #
 # $1 is the disk (e.g. /dev/sda)
 # $2 is the disk number
@@ -2097,6 +2159,7 @@ validateImageSectorSize() {
     [[ -n $sfdiskfilename ]] && imagesectorsize=$(awk '/^sector-size:/{print $2; exit}' "$sfdiskfilename")
     [[ -z $imagesectorsize ]] && return 0
     if [[ $imagesectorsize -ne $targetsectorsize ]]; then
+        nvmeReformatToSectorSize "$disk" "$imagesectorsize" && return 0
         handleError "Sector size mismatch (${FUNCNAME[0]})\n   Image was captured on a disk with ${imagesectorsize}-byte logical sectors, but $disk uses ${targetsectorsize}-byte logical sectors.\n   Partition-table and filesystem geometry cannot be translated between logical sector sizes, so this image cannot be deployed to this disk.\n   Deploy this image only to a disk with ${imagesectorsize}-byte logical sectors, or capture a new image on a disk with ${targetsectorsize}-byte logical sectors."
     fi
 }

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/partition-funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/partition-funcs.sh
@@ -80,8 +80,9 @@ applySfdiskPartitions() {
     local file="$2"
     [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
     [[ -z $file ]] && handleError "No file to receive from passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    flock $disk sfdisk $disk < $file >/dev/null 2>&1
-    [[ ! $? -eq 0 ]] && majorDebugEcho "sfdisk failed in (${FUNCNAME[0]})"
+    local sfdiskout
+    sfdiskout=$(flock $disk sfdisk $disk < $file 2>&1)
+    [[ ! $? -eq 0 ]] && handleError "sfdisk failed to apply the partition table to $disk (${FUNCNAME[0]})\n$sfdiskout"
 }
 # $1 is the name of the disk drive
 # $2 is name of file to load from.
@@ -385,7 +386,8 @@ fillSfdiskWithPartitions() {
         cat $tmp_file2
         majorDebugPause
     fi
-    [[ $status -eq 0 ]] && applySfdiskPartitions "$disk" "$tmp_file2"
+    [[ $status -ne 0 ]] && handleError "Could not compute a valid partition layout for $disk; the image may not fit the target disk (${FUNCNAME[0]})"
+    applySfdiskPartitions "$disk" "$tmp_file2"
     runPartprobe "$disk"
     rm -f $tmp_file2
     majorDebugEcho "Applied the preceding table."
@@ -447,6 +449,27 @@ processSfdisk() {
     [[ -z $target ]] && handleError "Device (disk or partition) not passed (${FUNCNAME[0]})\n   Args Passed: $*"
     [[ -z $size ]] && handleError "No desired size passed (${FUNCNAME[0]})\n   Args Passed: $*"
     local disk_size=$(blockdev --getsz ${disk})
+    # A whole-disk fill restores an image whose partition offsets/sizes were captured
+    # in the image's logical sector unit. Two awk inputs must track that unit or the
+    # fill math misbehaves on non-512 (e.g. 4Kn) targets:
+    #   diskSize    - blockdev --getsz always reports 512-byte units; convert it into
+    #                 the target's logical-sector unit, else every resizable partition
+    #                 inflates (~8x on 4Kn) and runs off the end of the disk.
+    #   SECTOR_SIZE - the fill engine uses this ONLY as a size-alignment quantum
+    #                 (p_size -= p_size % SECTOR_SIZE). 512 sectors = 256 KiB at
+    #                 512-byte sectors; feed that same 256 KiB granularity in the
+    #                 target's unit so a small resizable partition isn't rounded to 0
+    #                 (a 1 MiB bios_grub is 256 sectors on 4Kn; a 4096-sector quantum
+    #                 would zero it and corrupt the table).
+    # No-op on 512-byte-sector disks: getss=512 makes both identities
+    # (disk_size*512/512 = disk_size; 512*512/512 = 512).
+    if [[ $action == filldisk ]]; then
+        local logsectorsize=$(blockdev --getss ${disk} 2>/dev/null)
+        if [[ -n $logsectorsize && $logsectorsize -gt 0 ]]; then
+            disk_size=$(( disk_size * 512 / logsectorsize ))
+            sectorsize=$(( 512 * 512 / logsectorsize ))
+        fi
+    fi
     local minstart=$(awk -F'[ ,]+' '/start/{if ($4) print $4}' $data | sort -n | head -1)
     local chunksize=""
     getPartBlockSize "$disk" "chunksize"

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/procsfdisk.awk
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/procsfdisk.awk
@@ -559,6 +559,16 @@ function fill_disk(partition_names, partitions, args, n, fixed_partitions, origi
     curr_start = int(MIN_START);
     # Prior size should start as 0
     prior_size = 0;
+    # The exclusive upper bound for a partition's end. On GPT the tail of the
+    # disk holds the backup GPT header and partition-entry array (the same span
+    # firstlba reserves at the front), so nothing may run past diskSize -
+    # firstlba -- which is exactly the last-lba this function emits below, so the
+    # clamp and the emitted last-lba can never disagree. On non-GPT labels
+    # firstlba is unset and the whole disk is usable.
+    disk_end = int(diskSize);
+    if (firstlba) {
+        disk_end = int(diskSize) - int(firstlba);
+    }
     # Iterate the ordered start positions.
     for (i in ordered_starts) {
         # pName will be the ordered start position.
@@ -601,9 +611,11 @@ function fill_disk(partition_names, partitions, args, n, fixed_partitions, origi
         curr_start += p_size;
         # Set the partitions start to our adjusted start.
         partitions[pName, "start"] = p_start;
-        # Set the last boundary properly
-        if (p_start + p_size > int(diskSize)) {
-            p_size -= (p_start + p_size - int(diskSize));
+        # Set the last boundary properly, keeping GPT's reserved backup area
+        # (everything past disk_end) clear so the final partition can't overwrite
+        # the backup GPT header/entries.
+        if (p_start + p_size > disk_end) {
+            p_size -= (p_start + p_size - disk_end);
             p_size -= (p_size % int(SECTOR_SIZE));
             partitions[pName, "size"] = p_size;
         }
@@ -738,13 +750,13 @@ BEGIN {
     # If the action value is neither of the above fail out.
     switch (action) {
         case "resize":
-            resize_partition(partition_names, partitions, args);
+            rc = resize_partition(partition_names, partitions, args);
             break;
         case "move":
-            move_partition(partition_names, partitions, args);
+            rc = move_partition(partition_names, partitions, args);
             break;
         case "filldisk":
-            fill_disk(partition_names, partitions, args);
+            rc = fill_disk(partition_names, partitions, args);
             break;
         default:
             printf("Please enter a proper action.\n");
@@ -752,4 +764,9 @@ BEGIN {
     }
     # Display output.
     display_output(partition_names, partitions);
+    # A nonzero return means the computed table is inconsistent (e.g. fill_disk
+    # detected overlapping partitions). Exit non-zero so the caller refuses to
+    # apply a corrupt table instead of silently writing it to disk.
+    if (rc != 0)
+        exit(1);
 }

--- a/docs/adr/0001-sector-size-geometry-match-or-refuse.md
+++ b/docs/adr/0001-sector-size-geometry-match-or-refuse.md
@@ -20,11 +20,12 @@ does or that we can do reliably for an arbitrary captured image. A deploy that
 "succeeds" but silently produces an unbootable disk is worse than a clean
 refusal, so we refuse.
 
-The eventual answer for the tractable case (NVMe drives that expose both a 512-
-and a 4096-byte LBA format) is to reformat the *target* to match the image's
-sector size with `nvme format` before deploying — matching geometry rather than
-translating it. That is deliberately **out of scope here** and left to a later
-branch; this change is the safety net that must land first.
+The answer for the tractable case (NVMe drives that expose both a 512- and a
+4096-byte LBA format) is to reformat the *target* to match the image's sector
+size with `nvme format` before deploying — matching geometry rather than
+translating it. This change is the safety net that landed first; the reformat
+was added on top of it and is documented in
+[ADR-0002](0002-nvme-reformat-target-to-match-image.md).
 
 ## How it works
 
@@ -33,11 +34,14 @@ branch; this change is the safety net that must land first.
 first destructive write (`clearPartitionTables`). It compares the target's
 logical sector size (`blockdev --getss`) against the size recorded in the stored
 sfdisk dump's `sector-size:` line (checked in the same
-minimum → original → legacy precedence the restore path uses). It refuses **only
-when both sizes are known and differ**, calling the existing fatal
-`handleError`. If either side is unknown — `blockdev` can't read the target, or
-the dump records no source size — it returns without erroring, so it never
-introduces a new failure on a path that works today.
+minimum → original → legacy precedence the restore path uses). It acts **only
+when both sizes are known and differ**: it first tries to make the target match
+by reformatting an NVMe namespace to the image's sector size (see
+[ADR-0002](0002-nvme-reformat-target-to-match-image.md)), and only refuses —
+calling the existing fatal `handleError` — when that isn't possible. If either
+side is unknown — `blockdev` can't read the target, or the dump records no
+source size — it returns without erroring, so it never introduces a new failure
+on a path that works today.
 
 ## Known gaps (deliberate)
 

--- a/docs/adr/0002-nvme-reformat-target-to-match-image.md
+++ b/docs/adr/0002-nvme-reformat-target-to-match-image.md
@@ -1,0 +1,65 @@
+# Auto-reformat an NVMe target to match the image's sector size
+
+ADR-0001 established that FOS refuses a deploy when the image's logical sector
+size does not match the target disk's, because the geometry can't be translated
+on the fly. This ADR covers the one case that *is* tractable: an NVMe namespace
+that already exposes an LBA format at the image's sector size can simply be
+switched to it. When a mismatch is hit on such a target, FOS **low-level
+reformats the namespace to match the image and continues the deploy**, after a
+60-second cancelable countdown. The ADR-0001 refusal remains the fallback for
+every case a reformat can't fix (non-NVMe targets, or NVMe with no matching
+metadata-free LBA format).
+
+## How it works
+
+`validateImageSectorSize()` calls `nvmeReformatToSectorSize()` before it refuses.
+That function returns 0 (deploy proceeds) only after a reformat is confirmed to
+have taken effect, and non-zero (caller refuses) otherwise. It:
+
+1. Returns non-zero immediately unless the disk name matches `*nvme*`.
+2. Parses `nvme id-ns` and selects the first **metadata-free** (`ms:0`) LBA
+   format whose block size (`2^lbads`) equals the image's sector size. No match
+   → non-zero.
+3. Prints the warning and runs a 60-second `power-off-to-cancel` countdown.
+4. Runs `nvme format --lbaf=N --force`. If the command fails → non-zero.
+5. Re-reads the geometry (`runPartprobe` + `blockdev --getss`) and returns 0
+   only if the target now actually reports the image's sector size; otherwise
+   non-zero.
+
+## Why auto-reformat, not opt-in
+
+The alternative was to detect the reformattable case and stop, telling the
+operator to reformat manually or set a flag. We rejected that: the deploy is
+already going to erase the disk, the reformat is the only way this image will
+ever boot on this hardware, and requiring a manual `nvme format` step off in a
+shell defeats the point of an imaging appliance. Making it automatic — with a
+loud, cancelable window — keeps the common "just deploy it" path working while
+still giving the operator a chance to abort.
+
+## Why the 60-second countdown
+
+The reformat is a **low-level, irreversible** operation that destroys the
+namespace. We mirror `fog.wipe`'s existing safety idiom (a 60-second
+`usleep`-driven countdown with a "power off to cancel" prompt) rather than
+inventing a new confirmation mechanism or reformatting silently. Silent would be
+surprising and unrecoverable; a prompt requiring keyboard input can't work on an
+unattended/PXE deploy. The timed window is the same trade-off FOS already made
+for wiping a disk, applied to the same class of action.
+
+## Why metadata-free formats only
+
+Many NVMe drives expose 4096-byte LBA formats that also carry metadata
+(`ms>0`, used for protection information / T10-PI). Switching a namespace into a
+metadata format changes more than the logical block size and can leave the
+device in a state the image was never captured for. We only ever select `ms:0`
+formats; if the only matching-size format carries metadata, we treat it as no
+match and fall back to the refusal.
+
+## Consequences
+
+- A cross-sector-size deploy that used to be impossible now "just works" on NVMe
+  hardware that has a matching LBA format — at the cost of a low-level reformat
+  the operator has 60 seconds to stop.
+- True-4Kn NVMe drives with no 512-byte LBAF (and the reverse) still can't be
+  helped and still refuse, exactly as under ADR-0001.
+- The feature is entirely self-contained in FOS; it needs no FOG-server changes.

--- a/docs/adr/0003-fail-loud-on-partition-table-failure.md
+++ b/docs/adr/0003-fail-loud-on-partition-table-failure.md
@@ -1,0 +1,61 @@
+# Abort the run when the partition table can't be computed or applied
+
+The partition-restore path had three places where a failure was swallowed and
+init continued anyway: a computed layout could be inconsistent, or the write to
+disk could fail, and FOS would still proceed to the partclone restore. The
+result was a half-imaged or silently-wrong disk that reported success. We decided
+these are **fatal**: each now stops the run at the point of failure with a
+message, instead of continuing.
+
+## What changed
+
+Three sites, all in the fill/restore path:
+
+- **`applySfdiskPartitions()`** (`partition-funcs.sh`). A non-zero exit from the
+  `sfdisk` write went to `majorDebugEcho` — visible only in debug mode, otherwise
+  discarded. It now calls the fatal `handleError` and includes sfdisk's captured
+  stderr. This function is the single apply point for every caller (fill, restore,
+  resize, move, shrink), so the change covers all of them.
+- **`fillSfdiskWithPartitions()`** (`partition-funcs.sh`). The old code applied
+  the computed table only `[[ $status -eq 0 ]]` and, when the fill engine failed,
+  simply skipped the apply and continued — leaving whatever table was already on
+  the disk. It now `handleError`s on a non-zero status before reaching the apply,
+  so a disk that the image can't fit stops the deploy instead of being restored
+  onto a stale or wrong table.
+- **`fill_disk()` / the `END` block** (`procsfdisk.awk`). An inconsistent computed
+  table (overlap, or a partition pushed past the disk) printed an `ERROR` banner
+  into the emitted output but the awk still exited `0`, so the caller applied it.
+  The `END` block now propagates a non-zero exit (`if (rc != 0) exit(1)`), which
+  is the `status` that `fillSfdiskWithPartitions` above now refuses on.
+
+## Why hard-abort, and the trade-off
+
+The alternative was to keep warning and continuing. We rejected it because the
+failure modes here are silent: a dropped or overlapping partition, or an sfdisk
+write that didn't take, produces a disk that looks imaged but isn't bootable — and
+the operator finds out only when the machine won't start, far from the cause. A
+hard stop at the failing step is more honest and far easier to diagnose.
+
+The cost is that a hard-abort turns any *benign* non-zero exit into a failed
+deploy that would previously have completed. That risk was the specific target of
+an adversarial review of this change: it hunted for a real path where `sfdisk` or
+the awk returns non-zero while the table actually applied fine — a busy-disk
+`BLKRRPART` re-read, an odd util-linux 2.41.3 exit — and none survived
+verification. The kernel partition-table *re-read* (which genuinely can lag on a
+busy disk) is handled separately by `runPartprobe`, not by sfdisk's own exit
+code, so it isn't caught by this abort. We accept the residual risk: a spurious
+refusal is recoverable and loud, a silent mis-image is neither.
+
+## Verification
+
+`tests/checks/fill-engine.sh` locks all three: an unusable computed table makes
+the awk exit non-zero and `fillSfdiskWithPartitions` abort before any write, and
+a failing `sfdisk` stub makes `applySfdiskPartitions` abort. A negative-control
+run (each fix reverted) confirms every one of those cases goes red without the
+change.
+
+This hardening rides with the sector-size fill fixes it protects — the 4Kn
+disk-size rescale and the GPT backup-header clamp in the same fill engine — which
+support the geometry-matching work in
+[ADR-0001](0001-sector-size-geometry-match-or-refuse.md) and
+[ADR-0002](0002-nvme-reformat-target-to-match-image.md).

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,7 +34,15 @@ cases and exits non-zero if any fail.
 
 ```sh
 tests/checks/sector-size.sh   # validateImageSectorSize() refuses on a
-                              # logical-sector-size mismatch, allows on match
+                              # logical-sector-size mismatch, allows on match,
+                              # and reformats an NVMe target to the image's
+                              # sector size when it exposes a matching LBA format
+tests/checks/fill-engine.sh   # the whole-disk fill engine (processSfdisk +
+                              # fillSfdiskWithPartitions + fill_disk in the awk):
+                              # 4Kn sector-size rescaling keeps a small partition
+                              # alive, the GPT backup-header clamp holds, and an
+                              # unusable computed table aborts instead of being
+                              # written
 ```
 
 Like the golden harness, these source a sandbox copy of the library with its

--- a/tests/checks/fill-engine.sh
+++ b/tests/checks/fill-engine.sh
@@ -1,0 +1,327 @@
+#!/bin/bash
+#
+# Assertion harness for the whole-disk fill engine: processSfdisk() +
+# fillSfdiskWithPartitions() in partition-funcs.sh and fill_disk() in
+# procsfdisk.awk.
+#
+#   tests/checks/fill-engine.sh        # run all cases, exit non-zero on any failure
+#
+# The golden harness (tests/golden/) proves one fixed table stays byte-identical;
+# it can't express the invariants that matter when the target geometry differs
+# from the captured image. This harness drives the REAL awk through the REAL
+# shell entry points to lock three behaviours that have no other in-tree coverage:
+#
+#   1. Sector-size awareness (processSfdisk, filldisk only). blockdev --getsz
+#      always reports 512-byte units; on a 4Kn (getss=4096) target the disk size
+#      is rescaled into the image's logical-sector unit and the fill's alignment
+#      quantum (SECTOR_SIZE) is rescaled with it. If SECTOR_SIZE were left at 512
+#      a 1 MiB partition (256 sectors on 4Kn) aligns to 0 and is silently dropped;
+#      if diskSize were not rescaled every resizable partition inflates ~8x and
+#      runs off the end. A 512n target must be an exact no-op.
+#
+#   2. The GPT backup-header clamp (fill_disk). The last partition may not run
+#      past diskSize - firstlba, the last-usable LBA that holds the backup GPT
+#      header/entry array. A barely-fits image whose partitions all floor back to
+#      their captured sizes used to end exactly at diskSize, 34 sectors into that
+#      reserved area, while check_overlap still reported "consistent".
+#
+#   3. Fail-loud on an unusable table. An inconsistent computed table makes the
+#      awk exit non-zero; processSfdisk propagates that exit (the awk is its last
+#      command) and fillSfdiskWithPartitions aborts via handleError instead of
+#      applying a corrupt table. applySfdiskPartitions likewise aborts when the
+#      real sfdisk write fails rather than swallowing it into a debug line.
+#
+# Mechanism mirrors tests/checks/sector-size.sh: source a sandbox copy of the
+# library with the awk path rewritten to the in-tree script, PATH-shadow blockdev
+# (and, for the apply path, flock/sfdisk) with deterministic stubs, and override
+# the funcs.sh helpers the entry points call. handleError is overridden AFTER
+# sourcing so an abort is observable (it still exits the case subshell, as the
+# real one exits init).
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_LIB="$HERE/../../Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib"
+
+[[ -f $REPO_LIB/partition-funcs.sh ]] || { echo "ERROR: cannot find partition-funcs.sh under $REPO_LIB" >&2; exit 2; }
+[[ -f $REPO_LIB/procsfdisk.awk ]] || { echo "ERROR: cannot find procsfdisk.awk under $REPO_LIB" >&2; exit 2; }
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# Sandbox copy of the library with the hardcoded awk path rewritten to the in-tree
+# script, invoked via `awk -f` so the test does not depend on the file's mode bit.
+REALAWK="$REPO_LIB/procsfdisk.awk"
+sed -e "s#/usr/share/fog/lib/procsfdisk\.awk#awk -f $REALAWK#g" \
+    "$REPO_LIB/partition-funcs.sh" > "$SANDBOX/partition-funcs.sh"
+
+# --- deterministic stubs for the external tools the entry points shell out to ---
+STUBBIN="$SANDBOX/bin"
+mkdir -p "$STUBBIN"
+
+# blockdev: --getsz is the 512-byte-unit disk size, --getss the logical sector
+# size, --getpbsz the physical block size. All three come from the per-case FAKE_*
+# globals so a case can model any geometry.
+cat > "$STUBBIN/blockdev" <<'EOF'
+#!/bin/bash
+case "$1" in
+    --getsz)   printf '%s\n' "$FAKE_GETSZ" ;;
+    --getss)   printf '%s\n' "$FAKE_GETSS" ;;
+    --getpbsz) printf '%s\n' "$FAKE_GETPBSZ" ;;
+esac
+exit 0
+EOF
+chmod +x "$STUBBIN/blockdev"
+
+# flock <lockpath> <cmd...>: drop the lock argument and run the command, so the
+# real applySfdiskPartitions plumbing (flock $disk sfdisk $disk < file) exercises
+# the sfdisk stub with the table on stdin.
+cat > "$STUBBIN/flock" <<'EOF'
+#!/bin/bash
+shift
+exec "$@"
+EOF
+chmod +x "$STUBBIN/flock"
+
+# sfdisk double: consume the table on stdin, record that a write was attempted,
+# and exit $FAKE_SFDISK_RC so a case can model the write succeeding or failing.
+cat > "$STUBBIN/sfdisk" <<'EOF'
+#!/bin/bash
+cat >/dev/null 2>&1
+: > "$SANDBOX/applied"
+exit ${FAKE_SFDISK_RC:-0}
+EOF
+chmod +x "$STUBBIN/sfdisk"
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; [[ -n $2 ]] && echo "      $2"; FAIL=$((FAIL + 1)); }
+
+# --- parse helpers over $OUT (the emitted "sfdisk -d" table) ---
+# display_output prints:  <dev> : start=%12d, size=%12d, <type...>
+pstart() { printf '%s\n' "$OUT" | sed -n "s#^$1 : start= *\([0-9]\{1,\}\).*#\1#p" | head -1; }
+psize()  { printf '%s\n' "$OUT" | sed -n "s#^$1 : .*size= *\([0-9]\{1,\}\).*#\1#p" | head -1; }
+pend()   { echo $(( $(pstart "$1") + $(psize "$1") )); }
+
+# run_fill <dumpfile> <getsz> <getss> <fixedList> -- run processSfdisk filldisk on
+# a target with the given geometry; leaves the emitted table in $OUT and the awk's
+# (== processSfdisk's) exit in $RC.
+run_fill() {
+    local dump="$1" getsz="$2" getss="$3" fixed="$4"
+    OUT="$(
+        set +u
+        export PATH="$STUBBIN:$PATH"
+        export FAKE_GETSZ="$getsz" FAKE_GETSS="$getss" FAKE_GETPBSZ="$getss"
+        . "$SANDBOX/partition-funcs.sh"
+        handleError() { echo "ABORT: $*"; exit 1; }
+        handleWarning() { :; }
+        getPartBlockSize() { printf -v "$2" '%s' "$FAKE_GETPBSZ"; }
+        runPartprobe() { :; }
+        majorDebugEcho() { :; }; majorDebugPause() { :; }; majorDebugShowCurrentPartitionTable() { :; }
+        ismajordebug=0
+        disk="/dev/sdb"                        # processSfdisk reads the global $disk
+        processSfdisk "$dump" filldisk "/dev/sdb" "$getsz" "$fixed" "$dump"
+    )"
+    RC=$?
+}
+
+# ---------------------------------------------------------------------------
+# 1. 512n comfortable GPT fill: exact no-op on the sector-size scaling, valid
+#    table, last partition inside the last-usable LBA.
+DISK512=83886080                               # 40 GiB in 512-byte units
+END512=$(( DISK512 - 34 ))
+cat > "$SANDBOX/d.512" <<EOF
+label: gpt
+device: /dev/sdb
+unit: sectors
+first-lba: 34
+last-lba: $END512
+sector-size: 512
+
+/dev/sdb1 : start=        2048, size=      204800, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+/dev/sdb2 : start=      206848, size=     1048576, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+/dev/sdb3 : start=     1255424, size=    10485760, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+EOF
+run_fill "$SANDBOX/d.512" "$DISK512" 512 ""
+if [[ $RC -eq 0 && $OUT == *"consistent"* && $OUT != *ERROR* \
+      && $(psize /dev/sdb1) -gt 0 && $(pend /dev/sdb3) -le $END512 ]]; then
+    pass "512n GPT fill: valid table, sdb3 end $(pend /dev/sdb3) <= last-usable $END512"
+else
+    fail "512n GPT fill" "rc=$RC sdb1=$(psize /dev/sdb1) sdb3_end=$(pend /dev/sdb3) end=$END512
+$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. 4Kn fill: getsz is 8x the logical size, getss=4096. processSfdisk must
+#    rescale diskSize into 4K units and drop SECTOR_SIZE to 64 so the 1 MiB
+#    (256-sector) partition survives instead of aligning to 0. All partitions
+#    resizable so sdb1 actually goes through the alignment quantum.
+DISK4K_512=2097152                             # 1 GiB in 512-byte units
+DISK4K=$(( DISK4K_512 / 8 ))                   # 262144, in 4K units
+END4K=$(( DISK4K - 6 ))
+cat > "$SANDBOX/d.4k" <<EOF
+label: gpt
+device: /dev/sdb
+unit: sectors
+first-lba: 6
+last-lba: $END4K
+sector-size: 4096
+
+/dev/sdb1 : start=         256, size=         256, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+/dev/sdb2 : start=         512, size=       25600, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+/dev/sdb3 : start=       26112, size=      131072, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+EOF
+run_fill "$SANDBOX/d.4k" "$DISK4K_512" 4096 ""
+sdb1sz=$(psize /dev/sdb1)
+if [[ $RC -eq 0 && $OUT == *"consistent"* && $OUT != *ERROR* \
+      && $sdb1sz -gt 0 && $(( sdb1sz % 64 )) -eq 0 && $(pend /dev/sdb3) -le $END4K ]]; then
+    pass "4Kn fill: 256-sector partition survived (size=$sdb1sz), sdb3 end $(pend /dev/sdb3) <= $END4K"
+else
+    fail "4Kn fill (Edit C sector-size scaling)" "rc=$RC sdb1=$sdb1sz sdb3_end=$(pend /dev/sdb3) end=$END4K
+$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Barely-fits GPT: every partition floors back to its captured size so the
+#    last one would end exactly at diskSize without the clamp. It must instead
+#    stop at or before diskSize - firstlba.
+DISKBF=20969472
+ENDBF=$(( DISKBF - 34 ))
+cat > "$SANDBOX/d.bf" <<EOF
+label: gpt
+device: /dev/sdb
+unit: sectors
+first-lba: 34
+last-lba: $ENDBF
+sector-size: 512
+
+/dev/sdb1 : start=        2048, size=        2048, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+/dev/sdb2 : start=        4096, size=      204800, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+/dev/sdb3 : start=      208896, size=    20760576, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+EOF
+run_fill "$SANDBOX/d.bf" "$DISKBF" 512 ""
+if [[ $RC -eq 0 && $OUT == *"consistent"* && $OUT != *ERROR* \
+      && $(pend /dev/sdb3) -le $ENDBF ]]; then
+    pass "barely-fits GPT clamp: sdb3 end $(pend /dev/sdb3) <= last-usable $ENDBF (not into backup GPT)"
+else
+    fail "barely-fits GPT clamp" "rc=$RC sdb3_end=$(pend /dev/sdb3) end=$ENDBF diskSize=$DISKBF
+$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. MBR (dos) fill: no first-lba, so disk_end == diskSize and the clamp is a
+#    no-op; the table must still be valid and inside the disk.
+cat > "$SANDBOX/d.mbr" <<EOF
+label: dos
+device: /dev/sdb
+unit: sectors
+
+/dev/sdb1 : start=        2048, size=      204800, type=83
+/dev/sdb2 : start=      206848, size=     2097152, type=83
+/dev/sdb3 : start=     2304000, size=    18665472, type=83
+EOF
+run_fill "$SANDBOX/d.mbr" "$DISKBF" 512 ""
+if [[ $RC -eq 0 && $OUT == *"consistent"* && $OUT != *ERROR* \
+      && $(pend /dev/sdb3) -le $DISKBF ]]; then
+    pass "MBR fill: valid table, sdb3 end $(pend /dev/sdb3) <= disk $DISKBF"
+else
+    fail "MBR fill" "rc=$RC sdb3_end=$(pend /dev/sdb3) disk=$DISKBF
+$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Inconsistent table -> awk exits non-zero -> processSfdisk propagates it.
+#    Three fixed partitions whose cumulative captured sizes march a start past
+#    the end of the disk, which check_overlap rejects.
+cat > "$SANDBOX/d.bad" <<EOF
+label: dos
+device: /dev/sdb
+unit: sectors
+
+/dev/sdb1 : start=        2048, size=       90000, type=83
+/dev/sdb2 : start=       92048, size=       90000, type=83
+/dev/sdb3 : start=      182048, size=        2048, type=83
+EOF
+run_fill "$SANDBOX/d.bad" 100000 512 "1:2:3"
+if [[ $RC -ne 0 && $OUT == *ERROR* ]]; then
+    pass "inconsistent fill: awk exit $RC (non-zero) and reported an error"
+else
+    fail "inconsistent fill should exit non-zero" "rc=$RC
+$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# Fail-loud propagation through the shell entry points.
+# ---------------------------------------------------------------------------
+
+# apply_case <name> <sfdisk_rc> <expect: abort|noabort> -- run applySfdiskPartitions
+# against a stub sfdisk that exits $sfdisk_rc.
+apply_case() {
+    local name="$1" rc="$2" expect="$3" got
+    printf 'label: dos\n/dev/sdb1 : start=2048, size=2048, type=83\n' > "$SANDBOX/table"
+    local out
+    out="$(
+        set +u
+        export PATH="$STUBBIN:$PATH"
+        export SANDBOX="$SANDBOX" FAKE_SFDISK_RC="$rc"
+        . "$SANDBOX/partition-funcs.sh"
+        handleError() { echo "ABORT: $*"; exit 1; }
+        majorDebugEcho() { :; }
+        applySfdiskPartitions "/dev/sdb" "$SANDBOX/table"
+        echo "RETURNED"
+    )"
+    [[ $out == *"ABORT:"* ]] && got="abort" || got="noabort"
+    if [[ $got == "$expect" ]]; then
+        pass "$name (expected $expect)"
+    else
+        fail "$name" "expected $expect, got $got: $(printf '%s' "$out" | tr '\n' '|')"
+    fi
+}
+
+# 6. sfdisk write fails -> hard abort instead of a swallowed debug line.
+apply_case "applySfdiskPartitions aborts when sfdisk write fails" 1 abort
+# 7. sfdisk write succeeds -> no spurious abort.
+apply_case "applySfdiskPartitions succeeds silently on a good write" 0 noabort
+
+# fill_case <name> <dumpfile> <getsz> <fixed> <expect: abort|noabort> -- run the
+# full fillSfdiskWithPartitions; a computed table that is inconsistent must abort
+# before any sfdisk write, a good one must reach the write.
+fill_case() {
+    local name="$1" dump="$2" getsz="$3" fixed="$4" expect="$5" got
+    rm -f "$SANDBOX/applied"
+    local out
+    out="$(
+        set +u
+        export PATH="$STUBBIN:$PATH"
+        export SANDBOX="$SANDBOX" FAKE_GETSZ="$getsz" FAKE_GETSS=512 FAKE_GETPBSZ=512 FAKE_SFDISK_RC=0
+        . "$SANDBOX/partition-funcs.sh"
+        handleError() { echo "ABORT: $*"; exit 1; }
+        handleWarning() { :; }
+        getPartBlockSize() { printf -v "$2" '%s' 512; }
+        runPartprobe() { :; }
+        majorDebugEcho() { :; }; majorDebugPause() { :; }; majorDebugShowCurrentPartitionTable() { :; }
+        ismajordebug=0
+        fillSfdiskWithPartitions "/dev/sdb" "$dump" "$dump" "$fixed" "$dump"
+        echo "RETURNED"
+    )"
+    [[ $out == *"ABORT:"* ]] && got="abort" || got="noabort"
+    local applied="no"; [[ -f "$SANDBOX/applied" ]] && applied="yes"
+    if [[ $got == "$expect" ]]; then
+        # An abort must happen before the write; a non-abort must reach the write.
+        if { [[ $expect == abort && $applied == no ]] || [[ $expect == noabort && $applied == yes ]]; }; then
+            pass "$name (expected $expect, applied=$applied)"
+        else
+            fail "$name" "abort/apply mismatch: got $got applied=$applied"
+        fi
+    else
+        fail "$name" "expected $expect, got $got applied=$applied: $(printf '%s' "$out" | tr '\n' '|')"
+    fi
+}
+
+# 8. Unusable computed table -> abort before writing anything.
+fill_case "fillSfdiskWithPartitions aborts on an unusable layout" "$SANDBOX/d.bad" 100000 "1:2:3" abort
+# 9. Valid computed table -> proceed to the sfdisk write.
+fill_case "fillSfdiskWithPartitions applies a valid layout" "$SANDBOX/d.512" "$DISK512" "" noabort
+
+echo "----"
+echo "$PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/tests/checks/sector-size.sh
+++ b/tests/checks/sector-size.sh
@@ -29,17 +29,46 @@ cp "$REPO_LIB/partition-funcs.sh" "$SANDBOX/partition-funcs.sh"
 sed -e "s#^\. /usr/share/fog/lib/partition-funcs\.sh#. $SANDBOX/partition-funcs.sh#" \
     "$REPO_LIB/funcs.sh" > "$SANDBOX/funcs.sh"
 
-# --- deterministic stub for blockdev (--getss echoes $FAKE_SS) ---
+# --- deterministic stubs for the external tools the function shells out to ---
 STUBBIN="$SANDBOX/bin"
 mkdir -p "$STUBBIN"
+
+# blockdev: --getss returns the target's logical sector size. Before a reformat
+# that is $FAKE_SS (empty emulates blockdev failing to read the target); once the
+# nvme stub has dropped the "formatted" marker it returns $FAKE_SS_AFTER, so a
+# test can model the sector size changing (or not) as a result of nvme format.
+# --rereadpt (used by runPartprobe after a reformat) is a no-op that succeeds.
 cat > "$STUBBIN/blockdev" <<'EOF'
 #!/bin/bash
-# Only --getss is used by validateImageSectorSize. Echo the configured size;
-# an empty FAKE_SS emulates blockdev failing to read the target.
-[[ "$1" == "--getss" ]] && printf '%s\n' "$FAKE_SS"
+if [[ "$1" == "--getss" ]]; then
+    if [[ -f "$SANDBOX/formatted" ]]; then printf '%s\n' "$FAKE_SS_AFTER"; else printf '%s\n' "$FAKE_SS"; fi
+fi
 exit 0
 EOF
 chmod +x "$STUBBIN/blockdev"
+
+# nvme-cli double: id-ns lists the configured LBA formats ($FAKE_LBAFS); format
+# drops a marker so the blockdev stub reports the reformatted size, unless
+# $FAKE_FMT_FAIL is set (simulating a failed low-level format).
+cat > "$STUBBIN/nvme" <<'EOF'
+#!/bin/bash
+case "$1" in
+    id-ns) printf '%s\n' "$FAKE_LBAFS" ;;
+    format)
+        [[ -n $FAKE_FMT_FAIL ]] && exit 1
+        : > "$SANDBOX/formatted"
+        ;;
+esac
+exit 0
+EOF
+chmod +x "$STUBBIN/nvme"
+
+# No-op doubles for the countdown sleep and the tools runPartprobe calls, so the
+# reformat path runs instantly and touches nothing on the host.
+for tool in usleep udevadm umount; do
+    printf '#!/bin/bash\nexit 0\n' > "$STUBBIN/$tool"
+    chmod +x "$STUBBIN/$tool"
+done
 
 # Write a minimal but realistic sfdisk -d dump into $1. If $2 is non-empty it is
 # used as the sector-size value; if empty, the sector-size line is omitted (as a
@@ -60,19 +89,25 @@ write_dump() {
 PASS=0
 FAIL=0
 
-# run_case <name> <target_ss> <expect: abort|noabort> -- then the caller has
-# already populated $IMGDIR with the dump file(s) for this case.
+# run_case <name> <target_ss> <expect: abort|noabort> [disk] -- then the caller
+# has already populated $IMGDIR with the dump file(s) for this case. The optional
+# disk defaults to a non-NVMe /dev/sdb; pass /dev/nvme0n1 to exercise the reformat
+# path. The FAKE_LBAFS / FAKE_FMT_FAIL / FAKE_SS_AFTER globals (cleared by
+# new_imgdir) drive the nvme stub for reformat cases.
 run_case() {
-    local name="$1" target_ss="$2" expect="$3"
+    local name="$1" target_ss="$2" expect="$3" disk="${4:-/dev/sdb}"
     local out got
+    rm -f "$SANDBOX/formatted"
     out="$(
         set +u
         export PATH="$STUBBIN:$PATH"
+        export SANDBOX="$SANDBOX"
         export FAKE_SS="$target_ss"
+        export FAKE_SS_AFTER FAKE_LBAFS FAKE_FMT_FAIL
         . "$SANDBOX/funcs.sh"
         # Override AFTER sourcing so the real fatal handleError doesn't exit us.
         handleError() { echo "ABORT: $*"; }
-        validateImageSectorSize "/dev/sdb" "1" "$IMGDIR"
+        validateImageSectorSize "$disk" "1" "$IMGDIR"
         echo "RETURNED"
     )"
     if [[ $out == *"ABORT:"* ]]; then got="abort"; else got="noabort"; fi
@@ -86,8 +121,12 @@ run_case() {
     fi
 }
 
-# Each case gets a fresh image dir so leftover dumps can't cross-contaminate.
-new_imgdir() { IMGDIR="$SANDBOX/img.$1"; rm -rf "$IMGDIR"; mkdir -p "$IMGDIR"; }
+# Each case gets a fresh image dir so leftover dumps can't cross-contaminate, and
+# the reformat-stub knobs are reset so a prior case can't leak into this one.
+new_imgdir() {
+    IMGDIR="$SANDBOX/img.$1"; rm -rf "$IMGDIR"; mkdir -p "$IMGDIR"
+    FAKE_LBAFS=""; FAKE_FMT_FAIL=""; FAKE_SS_AFTER=""
+}
 
 # 1. Match: 512 image onto 512 disk -> allow.
 new_imgdir 1; write_dump "$IMGDIR/d1.minimum.partitions" 512
@@ -134,6 +173,52 @@ run_case "no sector-size line -> allow onto 4096-disk" 4096 noabort
 # (the standard case for a non-resizable image). 4096 image onto 512 -> refuse.
 new_imgdir 10; write_dump "$IMGDIR/d1.partitions" 4096
 run_case "d<N>.partitions is read when it is the only dump" 512 abort
+
+# --- NVMe reformat path: a mismatch on an NVMe target that exposes a matching
+# --- LBA format is resolved by reformatting instead of refused. ---
+
+# 11. NVMe target with a matching metadata-free (ms:0) LBA format: reformat the
+# namespace to the image's sector size and allow. 4096 image onto a 512 NVMe that
+# also exposes a 4096 format -> reformat -> allow.
+new_imgdir 11; write_dump "$IMGDIR/d1.minimum.partitions" 4096
+FAKE_LBAFS=$'lbaf  0 : ms:0   lbads:9  rp:0x1 (in use)\nlbaf  1 : ms:0   lbads:12 rp:0x2 '
+FAKE_SS_AFTER=4096
+run_case "nvme mismatch with matching lbaf -> reformat -> allow" 512 noabort /dev/nvme0n1
+
+# 12. NVMe target but no matching LBA format (only 512 exposed): can't reformat to
+# 4096, so fall back to the refusal.
+new_imgdir 12; write_dump "$IMGDIR/d1.minimum.partitions" 4096
+FAKE_LBAFS=$'lbaf  0 : ms:0   lbads:9  rp:0x1 (in use)'
+run_case "nvme mismatch, no matching lbaf -> refuse" 512 abort /dev/nvme0n1
+
+# 13. NVMe target whose only 4096 format carries metadata (ms:8): we never switch
+# a namespace into a metadata/PI format, so fall back to the refusal. FAKE_SS_AFTER
+# is set so that if the ms:0 gate were dropped and we DID reformat into lbaf 1, the
+# size would look correct and wrongly allow -- the abort proves the gate holds.
+new_imgdir 13; write_dump "$IMGDIR/d1.minimum.partitions" 4096
+FAKE_LBAFS=$'lbaf  0 : ms:0   lbads:9  rp:0x1 (in use)\nlbaf  1 : ms:8   lbads:12 rp:0x2 '
+FAKE_SS_AFTER=4096
+run_case "nvme mismatch, only metadata lbaf matches -> refuse" 512 abort /dev/nvme0n1
+
+# 14. Non-NVMe target: even with a matching format advertised, a SATA disk can't
+# be nvme-formatted, so a mismatch still refuses. Guards the nvme-only gate.
+new_imgdir 14; write_dump "$IMGDIR/d1.minimum.partitions" 4096
+FAKE_LBAFS=$'lbaf  0 : ms:0   lbads:9  rp:0x1 (in use)\nlbaf  1 : ms:0   lbads:12 rp:0x2 '
+FAKE_SS_AFTER=4096
+run_case "non-nvme mismatch is never reformatted -> refuse" 512 abort /dev/sdb
+
+# 15. NVMe reformat command itself fails: never proceed on a half-formatted disk.
+new_imgdir 15; write_dump "$IMGDIR/d1.minimum.partitions" 4096
+FAKE_LBAFS=$'lbaf  0 : ms:0   lbads:9  rp:0x1 (in use)\nlbaf  1 : ms:0   lbads:12 rp:0x2 '
+FAKE_FMT_FAIL=1
+run_case "nvme format fails -> refuse" 512 abort /dev/nvme0n1
+
+# 16. NVMe reformat reports success but the sector size did not actually change:
+# verify the new geometry before proceeding, else refuse.
+new_imgdir 16; write_dump "$IMGDIR/d1.minimum.partitions" 4096
+FAKE_LBAFS=$'lbaf  0 : ms:0   lbads:9  rp:0x1 (in use)\nlbaf  1 : ms:0   lbads:12 rp:0x2 '
+FAKE_SS_AFTER=512
+run_case "nvme format did not change sector size -> refuse" 512 abort /dev/nvme0n1
 
 echo "----"
 echo "$PASS passed, $FAIL failed"


### PR DESCRIPTION
## What

Second phase of the sector-size deploy work. The safety net that **refuses** a
logical-sector-size mismatch shipped earlier (ADR-0001). This PR adds the
tractable fix — reformat the target to match the image — and hardens the
whole-disk fill path it depends on.

## Changes

- **NVMe target reformat** (`funcs.sh` `nvmeReformatToSectorSize`, hooked into
  `validateImageSectorSize`). When the target is an NVMe namespace exposing an
  LBA format that matches the image's logical sector size, low-level reformat it
  to that size (`nvme format`) so the image can deploy, instead of refusing. A
  **60-second cancelable countdown** precedes the erase; no matching format or an
  unconfirmed reformat falls back to the existing refusal. (ADR-0002)

- **Fill-engine sector-size awareness** (`partition-funcs.sh` `processSfdisk`).
  Rescales the awk's `diskSize` (`blockdev --getsz` always reports 512-byte
  units) and its size-alignment quantum into the image's logical-sector unit for
  `filldisk`. On 4Kn targets partitions no longer inflate ~8× off the end of the
  disk, and a small resizable partition (a 1 MiB `bios_grub` is 256 sectors on
  4Kn) is no longer rounded to zero and silently dropped. Exact no-op on 512n.

- **GPT backup-header clamp** (`procsfdisk.awk` `fill_disk`). Clamps the last
  partition's end to `diskSize - firstlba` (the last-usable LBA it already
  emits) so a barely-fits image can't push the final partition into the reserved
  backup GPT header / entry array while still reporting the table "consistent".

- **Fail loud instead of silently continuing** (`partition-funcs.sh` +
  `procsfdisk.awk`). An unusable computed table, a non-zero fill-engine exit, or
  a failed `sfdisk` write now abort the run with a message rather than proceeding
  to a half-imaged or silently-wrong disk. (ADR-0003)

## Tests

- **`tests/checks/fill-engine.sh`** (new) drives the real awk through the real
  `processSfdisk` / `fillSfdiskWithPartitions` / `applySfdiskPartitions` entry
  points and asserts engine invariants (4Kn small-partition survival, GPT clamp,
  fail-loud propagation). Verified with a **negative control**: reverting each
  fix in throwaway copies turns exactly the matching case red.
- Reformat cases added to **`tests/checks/sector-size.sh`**.
- Both harnesses green (`fill-engine.sh` 9/9, `sector-size.sh` 16/16).

## Not covered (deliberate)

- `dd` whole-disk images (no captured geometry), `nombr`/single-partition
  restores (skip the table rewrite), and pre-util-linux-2.35 dumps (no
  `sector-size:` line). Documented in ADR-0001.
- Real 512n/4Kn **hardware validation** of the full capture→reformat→deploy path
  is the intended pre-release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
