### PR TITLE
Name the device class in sector-size refusals; record why only NVMe reformats

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -2111,6 +2111,41 @@ nvmeReformatToSectorSize() {
     echo "Done"
     return 0
 }
+# Emits (on stdout) one device-class-specific line for the sector-size-mismatch
+# refusal, telling the operator whether this class of target could ever match the
+# image's sector size and where the fix lives if so. Emits nothing for classes
+# with no useful class-specific advice (plain SATA/SAS/USB targets); the generic
+# remedy in the refusal message covers those. The per-class reasoning — why only
+# NVMe gets an automatic reformat — is docs/adr/0005-non-nvme-sector-size-mismatch-stays-refusal-only.md
+#
+# $1 is the disk (e.g. /dev/mmcblk0)
+# $2 is the image's sector size in bytes
+# $3 is the target disk's sector size in bytes
+sectorSizeMismatchHint() {
+    local disk="$1"
+    local wantsize="$2"
+    local havesize="$3"
+    local name="${disk##*/}"
+    case "$name" in
+        mmcblk*)
+            echo "$disk is an eMMC/SD device; its ${havesize}-byte logical sector size is fixed by the MMC/SD specification and cannot be changed. Only an image captured on ${havesize}-byte-sector hardware can deploy to it."
+            ;;
+        nvme*)
+            echo "$disk is an NVMe device but exposes no metadata-free ${wantsize}-byte LBA format, so it cannot be low-level reformatted to match this image."
+            ;;
+        vd*|xvd*)
+            echo "$disk is a virtual disk; its logical sector size is set by the hypervisor (e.g. the disk's logical_block_size property in QEMU/libvirt) and can only be changed in the VM configuration."
+            ;;
+        sd*)
+            # UFS modules surface as plain SCSI disks; the transport only shows in
+            # the SCSI host driver's name (ufshcd), so classify via sysfs.
+            local host=$(readlink -f "/sys/block/$name/device" 2>/dev/null | grep -o 'host[0-9][0-9]*' | head -1)
+            local hostdriver=""
+            [[ -n $host ]] && hostdriver=$(cat "/sys/class/scsi_host/$host/proc_name" 2>/dev/null)
+            [[ $hostdriver == ufshcd* ]] && echo "$disk is a UFS device; its ${havesize}-byte logical sector size is fixed when the module is provisioned at the factory and cannot be changed in the field. Only an image captured on ${havesize}-byte-sector hardware can deploy to it."
+            ;;
+    esac
+}
 # Refuses a deploy when the target disk's logical sector size does not match the
 # sector size the image was captured with. Partition-table LBA units and
 # filesystem metadata bake in the source disk's logical sector size at capture
@@ -2160,7 +2195,9 @@ validateImageSectorSize() {
     [[ -z $imagesectorsize ]] && return 0
     if [[ $imagesectorsize -ne $targetsectorsize ]]; then
         nvmeReformatToSectorSize "$disk" "$imagesectorsize" && return 0
-        handleError "Sector size mismatch (${FUNCNAME[0]})\n   Image was captured on a disk with ${imagesectorsize}-byte logical sectors, but $disk uses ${targetsectorsize}-byte logical sectors.\n   Partition-table and filesystem geometry cannot be translated between logical sector sizes, so this image cannot be deployed to this disk.\n   Deploy this image only to a disk with ${imagesectorsize}-byte logical sectors, or capture a new image on a disk with ${targetsectorsize}-byte logical sectors."
+        local hint=$(sectorSizeMismatchHint "$disk" "$imagesectorsize" "$targetsectorsize")
+        [[ -n $hint ]] && hint="\n   ${hint}"
+        handleError "Sector size mismatch (${FUNCNAME[0]})\n   Image was captured on a disk with ${imagesectorsize}-byte logical sectors, but $disk uses ${targetsectorsize}-byte logical sectors.\n   Partition-table and filesystem geometry cannot be translated between logical sector sizes, so this image cannot be deployed to this disk.${hint}\n   Deploy this image only to a disk with ${imagesectorsize}-byte logical sectors, or capture a new image on a disk with ${targetsectorsize}-byte logical sectors."
     fi
 }
 # Restores the partition tables and boot loaders

--- a/docs/adr/0005-non-nvme-sector-size-mismatch-stays-refusal-only.md
+++ b/docs/adr/0005-non-nvme-sector-size-mismatch-stays-refusal-only.md
@@ -1,0 +1,85 @@
+# Non-NVMe sector-size mismatches stay refusal-only, with device-class advice
+
+ADR-0001 refuses a deploy when the image's logical sector size doesn't match the
+target disk's; ADR-0002 carved out the one tractable exception, low-level
+reformatting an NVMe namespace that exposes a matching LBA format. The natural
+follow-up question is whether the same trick extends to the other storage
+classes FOS deploys to — eMMC/SD, UFS, SATA, SAS, USB-attached, and virtual
+disks. We surveyed each class and decided: **no other class gets an automatic
+reformat.** The mismatch stays a refusal everywhere but NVMe, and instead the
+refusal message gains one device-class-specific line
+(`sectorSizeMismatchHint()`) telling the operator whether this target's sector
+size could *ever* change and where the fix actually lives.
+
+## The survey, class by class
+
+What made ADR-0002 tractable on NVMe was the combination of: a standardized,
+in-band command (`nvme format`), broad device support, an immediate effect, and
+a way to verify the new geometry before proceeding. No other class has all four.
+
+- **eMMC / SD (`mmcblk*`).** The MMC/SD specifications fix sector addressing at
+  512 bytes and the Linux mmc block driver exposes exactly that. There is no
+  LBA-format concept and no command to change it — not a gap in our tooling, a
+  property of the hardware class. The only mismatch these can hit is a
+  4096-byte image deployed *to* them, and the only fix is capture-side.
+
+- **UFS (SCSI disks on a `ufshcd` host).** The mirror image: JEDEC UFS mandates
+  a minimum 4096-byte logical block, set per-LU in the configuration descriptor
+  at provisioning time. Rewriting that means reprovisioning the device — it
+  destroys every LU, is commonly one-time-locked by the OEM
+  (`bConfigDescrLock`), and can permanently brick a soldered-down part. An
+  imaging appliance has no business issuing it. Note the common *capture-side*
+  flow already works: an image captured on a UFS machine (4096) deploying to an
+  NVMe target is exactly what ADR-0002 handles.
+
+- **SATA.** A real mechanism exists — ACS-4 SET SECTOR CONFIGURATION
+  ("FastFormat"), reachable via `hdparm --set-sector-size`, and FOS ships a
+  new-enough hdparm. Rejected anyway: only a slice of enterprise
+  512e/4Kn-convertible drives implement it, and drives generally require a
+  power cycle or link reset before the new size is visible. That breaks the
+  format → re-read → confirm → continue sequence ADR-0002 depends on: a
+  post-format verification that can't see the new size yet would mean we
+  destroyed the disk and *then* refused. If field demand ever materializes,
+  this is the one class worth revisiting.
+
+- **SAS.** `sg_format` can re-sector many enterprise SAS drives, but FOS
+  doesn't ship sg3_utils (`sdparm` cannot issue FORMAT UNIT), a full format can
+  run for hours on spinning media, and SAS deploy targets are a rounding error
+  in the install base.
+
+- **USB-attached and virtual disks (`sd*` behind usb-storage/uas, `vd*`,
+  `xvd*`).** The USB bridge chip or the hypervisor dictates the logical size;
+  nothing can change it from inside the guest OS. For virtual disks there is at
+  least an operator-reachable knob — the disk's `logical_block_size` property
+  in QEMU/libvirt — so the hint points there.
+
+## What we did instead
+
+`validateImageSectorSize()` already tries the NVMe reformat and falls back to
+the ADR-0001 refusal. `sectorSizeMismatchHint()` now classifies the target
+(device name for `mmcblk*`/`nvme*`/`vd*`/`xvd*`; the SCSI host driver's
+`proc_name` in sysfs to spot `ufshcd`, since UFS surfaces as a plain `sd*`
+disk) and appends one line to the refusal:
+
+- eMMC/SD and UFS: the size is **fixed in hardware**; only a matching-geometry
+  image can ever deploy here — recapture is the fix.
+- NVMe that still refused: the drive **exposes no metadata-free LBA format** at
+  the image's size, so the ADR-0002 reformat couldn't help.
+- Virtual disks: the size is set by the **hypervisor** and can be changed in
+  the VM configuration.
+- Everything else (plain SATA/SAS/USB): no extra line; the generic remedy in
+  the refusal already says all we know.
+
+Classification failing (no sysfs entry, unrecognized name) just omits the line;
+it can never block or alter the refusal decision itself.
+
+## Consequences
+
+- Refusal behavior is unchanged everywhere; this only adds explanation. The
+  operator staring at a refused deploy on an eMMC tablet now learns the target
+  can never match, instead of wondering which side to "fix."
+- The per-class reasoning is recorded here so the "can't we just reformat it
+  like NVMe?" question has a written answer.
+- Revisit trigger for SATA FastFormat: shipped hdparm supports it today; what's
+  missing is confidence in in-band re-read after the command and evidence of
+  real fleets that need it.

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,8 +35,10 @@ cases and exits non-zero if any fail.
 ```sh
 tests/checks/sector-size.sh   # validateImageSectorSize() refuses on a
                               # logical-sector-size mismatch, allows on match,
-                              # and reformats an NVMe target to the image's
-                              # sector size when it exposes a matching LBA format
+                              # reformats an NVMe target to the image's sector
+                              # size when it exposes a matching LBA format, and
+                              # names the device class (eMMC/UFS/virtual/NVMe)
+                              # in the refusal when the target's size is fixed
 tests/checks/fill-engine.sh   # the whole-disk fill engine (processSfdisk +
                               # fillSfdiskWithPartitions + fill_disk in the awk):
                               # 4Kn sector-size rescaling keeps a small partition

--- a/tests/checks/sector-size.sh
+++ b/tests/checks/sector-size.sh
@@ -25,9 +25,26 @@ SANDBOX="$(mktemp -d)"
 trap 'rm -rf "$SANDBOX"' EXIT
 
 # --- sandbox copy of the library with host-absolute paths rewritten ---
+# /sys/block and /sys/class/scsi_host are rewritten into the sandbox so the
+# device classifier (sectorSizeMismatchHint) reads a fake sysfs we control
+# instead of whatever disks the dev machine happens to have.
 cp "$REPO_LIB/partition-funcs.sh" "$SANDBOX/partition-funcs.sh"
 sed -e "s#^\. /usr/share/fog/lib/partition-funcs\.sh#. $SANDBOX/partition-funcs.sh#" \
+    -e "s#/sys/block#$SANDBOX/sys/block#g" \
+    -e "s#/sys/class/scsi_host#$SANDBOX/sys/class/scsi_host#g" \
     "$REPO_LIB/funcs.sh" > "$SANDBOX/funcs.sh"
+
+# Fake sysfs: sdu is a UFS disk (SCSI host driver ufshcd), sdb is plain SATA
+# (ahci). Any device with no sysfs entry at all (e.g. sdz) exercises the
+# classifier's it-can't-tell path.
+for dev_host_driver in "sdu 0 ufshcd" "sdb 1 ahci"; do
+    set -- $dev_host_driver
+    mkdir -p "$SANDBOX/sys/devices/pci0/host$2/target$2:0:0/$2:0:0:0" \
+             "$SANDBOX/sys/block/$1" \
+             "$SANDBOX/sys/class/scsi_host/host$2"
+    ln -s "$SANDBOX/sys/devices/pci0/host$2/target$2:0:0/$2:0:0:0" "$SANDBOX/sys/block/$1/device"
+    echo "$3" > "$SANDBOX/sys/class/scsi_host/host$2/proc_name"
+done
 
 # --- deterministic stubs for the external tools the function shells out to ---
 STUBBIN="$SANDBOX/bin"
@@ -89,13 +106,15 @@ write_dump() {
 PASS=0
 FAIL=0
 
-# run_case <name> <target_ss> <expect: abort|noabort> [disk] -- then the caller
-# has already populated $IMGDIR with the dump file(s) for this case. The optional
-# disk defaults to a non-NVMe /dev/sdb; pass /dev/nvme0n1 to exercise the reformat
-# path. The FAKE_LBAFS / FAKE_FMT_FAIL / FAKE_SS_AFTER globals (cleared by
-# new_imgdir) drive the nvme stub for reformat cases.
+# run_case <name> <target_ss> <expect: abort|noabort> [disk] [want_sub] [forbid_sub]
+# -- the caller has already populated $IMGDIR with the dump file(s) for this case.
+# The optional disk defaults to a non-NVMe /dev/sdb; pass /dev/nvme0n1 to exercise
+# the reformat path. The FAKE_LBAFS / FAKE_FMT_FAIL / FAKE_SS_AFTER globals
+# (cleared by new_imgdir) drive the nvme stub for reformat cases. want_sub, if
+# given, must appear in the output (asserts a device-class hint was emitted);
+# forbid_sub must NOT appear (asserts one wasn't).
 run_case() {
-    local name="$1" target_ss="$2" expect="$3" disk="${4:-/dev/sdb}"
+    local name="$1" target_ss="$2" expect="$3" disk="${4:-/dev/sdb}" want_sub="$5" forbid_sub="$6"
     local out got
     rm -f "$SANDBOX/formatted"
     out="$(
@@ -111,11 +130,15 @@ run_case() {
         echo "RETURNED"
     )"
     if [[ $out == *"ABORT:"* ]]; then got="abort"; else got="noabort"; fi
-    if [[ $got == "$expect" ]]; then
+    local why=""
+    [[ $got != "$expect" ]] && why="expected $expect, got $got"
+    [[ -n $want_sub && $out != *"$want_sub"* ]] && why="${why:+$why; }missing \"$want_sub\""
+    [[ -n $forbid_sub && $out == *"$forbid_sub"* ]] && why="${why:+$why; }contains forbidden \"$forbid_sub\""
+    if [[ -z $why ]]; then
         echo "PASS: $name (expected $expect)"
         PASS=$((PASS + 1))
     else
-        echo "FAIL: $name (expected $expect, got $got)"
+        echo "FAIL: $name ($why)"
         echo "      output: $(printf '%s' "$out" | tr '\n' '|')"
         FAIL=$((FAIL + 1))
     fi
@@ -219,6 +242,38 @@ new_imgdir 16; write_dump "$IMGDIR/d1.minimum.partitions" 4096
 FAKE_LBAFS=$'lbaf  0 : ms:0   lbads:9  rp:0x1 (in use)\nlbaf  1 : ms:0   lbads:12 rp:0x2 '
 FAKE_SS_AFTER=512
 run_case "nvme format did not change sector size -> refuse" 512 abort /dev/nvme0n1
+
+# --- Device-class hints: the refusal names the device class and says whether its
+# --- sector size could ever be changed (sectorSizeMismatchHint, ADR-0005). ---
+
+# 17. eMMC/SD target: refuse and say the 512-byte size is fixed by the spec.
+new_imgdir 17; write_dump "$IMGDIR/d1.minimum.partitions" 4096
+run_case "emmc mismatch -> refuse with fixed-size hint" 512 abort /dev/mmcblk0 "eMMC/SD"
+
+# 18. NVMe target with no matching LBA format: the refusal explains why the
+# reformat path could not help this particular drive.
+new_imgdir 18; write_dump "$IMGDIR/d1.minimum.partitions" 4096
+FAKE_LBAFS=$'lbaf  0 : ms:0   lbads:9  rp:0x1 (in use)'
+run_case "nvme refusal names the missing lbaf" 512 abort /dev/nvme0n1 "no metadata-free 4096-byte LBA format"
+
+# 19. Virtual disk target: refuse and point at the hypervisor's disk config.
+new_imgdir 19; write_dump "$IMGDIR/d1.minimum.partitions" 4096
+run_case "virtio mismatch -> refuse with hypervisor hint" 512 abort /dev/vda "hypervisor"
+
+# 20. UFS target (a SCSI disk whose host driver is ufshcd in the fake sysfs):
+# refuse and say the size was fixed at factory provisioning.
+new_imgdir 20; write_dump "$IMGDIR/d1.minimum.partitions" 512
+run_case "ufs mismatch -> refuse with provisioning hint" 4096 abort /dev/sdu "UFS device"
+
+# 21. Plain SATA target (host driver ahci in the fake sysfs): refuse with the
+# generic message only -- no class hint applies.
+new_imgdir 21; write_dump "$IMGDIR/d1.minimum.partitions" 4096
+run_case "sata mismatch -> refuse without class hint" 512 abort /dev/sdb "" "UFS device"
+
+# 22. SCSI disk with no sysfs entry at all: the classifier can't tell, so the
+# refusal must still fire cleanly with the generic message.
+new_imgdir 22; write_dump "$IMGDIR/d1.minimum.partitions" 4096
+run_case "unclassifiable sd disk -> plain refuse" 512 abort /dev/sdz "" "UFS device"
 
 echo "----"
 echo "$PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- Follow-up to #119: surveys whether the NVMe LBA-format auto-reformat can extend to other device classes (eMMC/SD, UFS, SATA, SAS, USB, virtual). Conclusion: it can't — recorded in ADR-0005 with per-class reasoning and a revisit trigger for SATA FastFormat.
- Adds `sectorSizeMismatchHint()`: the sector-size refusal now names the target's device class and says whether its logical sector size could ever change and where the fix lives (recapture for eMMC/UFS, hypervisor config for virtual disks, no-matching-LBAF for NVMe that still refused).
- Classification failure just omits the hint line — it can never alter the refusal decision itself. No behavior change anywhere; refusals only gain explanation.

## Details
- UFS modules surface as plain `sd*` SCSI disks, so they're classified via the SCSI host driver's `proc_name` (`ufshcd`) in sysfs.
- Plain SATA/SAS/USB targets get no extra line — the generic remedy already says all we know.

## Testing
- `tests/checks/sector-size.sh` — 6 new cases (17–22): each hint class plus a plain-SATA and an unclassifiable no-hint case, with a fake sysfs in the sandbox for the UFS classifier. 22/22 pass.
- `tests/checks/fill-engine.sh` and the golden suite both pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)