### PR TITLE
Resize LVM images: shrink at capture, grow or rebuild at deploy

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.upload
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.upload
@@ -46,7 +46,7 @@ beginUpload() {
                 fsTypeSetting "$part"
                 getPartitionNumber "$part"
                 case $fstype in
-                    ntfs|extfs|btrfs|f2fs|xfs)
+                    ntfs|extfs|btrfs|f2fs|xfs|lvm)
                         continue
                         ;;
                     *)
@@ -62,8 +62,9 @@ beginUpload() {
             countPartTypes "$hd" "btrfs" "btrfscnt"
             countPartTypes "$hd" "f2fs" "f2fscnt"
             countPartTypes "$hd" "xfs" "xfscnt"
+            countPartTypes "$hd" "lvm" "lvmcnt"
             countPartTypes "$hd" "*" "partscnt"
-            if [[ $ntfscnt -eq 0 && $extfscnt -eq 0 && $btrfscnt -eq 0 && $f2fscnt -eq 0 && $xfscnt -eq 0 ]]; then
+            if [[ $ntfscnt -eq 0 && $extfscnt -eq 0 && $btrfscnt -eq 0 && $f2fscnt -eq 0 && $xfscnt -eq 0 && $lvmcnt -eq 0 ]]; then
                 echo "Failed"
                 debugPause
                 handleError "No resizable partitions found ($0)\n   Args Passed: $*"
@@ -79,6 +80,8 @@ beginUpload() {
             echo " * F2FS Partition count of: $f2fscnt"
             debugPause
             echo " * XFS Partition count of: $xfscnt"
+            debugPause
+            echo " * LVM Partition count of: $lvmcnt"
             debugPause
             echo " * Total Partition count of: $partscnt"
             debugPause
@@ -170,6 +173,7 @@ beginUpload() {
                 debugPause
                 applySfdiskPartitions "$hd" "$imagePath/d1.shrunken.partitions"
             fi
+            applyLVMMinimumSizes "$hd" 1 "$imagePath"
             echo " * Processing Hard Disk: $hd"
             for part in $parts; do
                 savePartition "$part" 1 "$imagePath" "$imgPartitionType"

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -342,6 +342,9 @@ expandPartition() {
                 fi
             fi
             ;;
+        lvm)
+            expandLVMPartition "$part"
+            ;;
         *)
             echo " * Not expanding ($part -- $fstype)"
             debugPause
@@ -745,6 +748,9 @@ shrinkPartition() {
             ;;
         xfs)
             echo " * Cannot shrink XFS partitions"
+            ;;
+        lvm)
+            shrinkLVMPartition "$part"
             ;;
         *)
             echo " * Not shrinking ($part $fstype)"
@@ -2688,7 +2694,7 @@ getLGDevice() {
     lgdev="/dev/mapper/${lggroup}-${lgvol}"
     read lgvUUID lgvSIZE <<< $(lvs --noheadings -v ${lggroup} --units s 2>/dev/null | awk '/'${lgvol}'/ {printf("%s %s", $5, gensub(/[Ss]/,"","g",$10))}')
 }
-# --- LVM per-LV capture and deploy (Phase 1, docs/adr/0004) -----------------
+# --- LVM per-LV capture and deploy (docs/adr/0004, resize docs/adr/0006) ----
 #
 # A partition holding an LVM2 physical volume is not sector-imaged. Capture
 # writes sidecar files next to the usual dNpM ones plus one partclone image
@@ -2696,10 +2702,15 @@ getLGDevice() {
 #   dNpM.lvm        versioned schema: PV/VG identity and one line per LV
 #   dNpM.lvm.vgcfg  vgcfgbackup output (complete LVM metadata, all UUIDs)
 #   dNpM.<lv>.img   partclone image per non-swap LV
-# Deploy recreates the stack with pvcreate --restorefile + vgcfgrestore (the
-# partition is recreated at its original size, so the extent geometry in the
-# backup still fits) and restores each LV. LV devices are addressed as
-# /dev/<vg>/<lv> and never enter the partition-name machinery.
+# Resizable captures first shrink the ext filesystems inside the LVs and
+# record per-LV minimum sizes (LVMFORMAT 2), letting the deploy fill engine
+# scale the PV partition. Deploy dispatches on the target partition size:
+# same size or larger restores with pvcreate --restorefile + vgcfgrestore
+# (all UUIDs preserved; extra space goes to the LVs proportionally), smaller
+# rebuilds the stack with vgcreate/lvcreate at the recorded minimums plus a
+# proportional share (VG/LV UUIDs regenerate; PV, filesystem, and swap UUIDs
+# survive). LV devices are addressed as /dev/<vg>/<lv> and never enter the
+# partition-name machinery.
 #
 # Streams one block device through partclone into the image store, the same
 # way savePartition's inline capture does for a plain partition.
@@ -2738,11 +2749,231 @@ savePartclone() {
     esac
     rm -rf $fifoname >/dev/null 2>&1
 }
+# Interrogates the LVM stack on a PV partition. Sets:
+#   lvm_vggroup      volume group name (empty if none)
+#   lvm_pvuuid       PV UUID
+#   lvm_pvsize       PV size in 512-byte sectors
+#   lvm_unsupported  why per-LV handling cannot apply (empty if supported)
+#
+# $1 = partition device holding the PV
+probeLVMPartition() {
+    local part="$1"
+    [[ -z $part ]] && handleError "No partition passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    vgscan >/dev/null 2>&1
+    lvm_vggroup=$(trim "$(pvs --noheadings -o vg_name "$part" 2>/dev/null)")
+    lvm_pvuuid=$(trim "$(pvs --noheadings -o pv_uuid "$part" 2>/dev/null)")
+    lvm_pvsize=$(pvs --noheadings --units s --nosuffix -o pv_size "$part" 2>/dev/null | awk '{printf("%d",$1)}')
+    local pvcount=$(vgs --noheadings -o pv_count "$lvm_vggroup" 2>/dev/null | awk '{printf("%d",$1)}')
+    lvm_unsupported=""
+    if [[ -z $lvm_vggroup ]]; then
+        lvm_unsupported="no volume group found on the physical volume"
+    elif [[ $pvcount -ne 1 ]]; then
+        lvm_unsupported="volume group $lvm_vggroup spans $pvcount physical volumes"
+    elif lvs --noheadings -o lv_layout "$lvm_vggroup" 2>/dev/null | grep -qv '^[[:space:]]*linear[[:space:]]*$'; then
+        lvm_unsupported="volume group $lvm_vggroup contains non-linear volumes (thin/RAID/cache/snapshot)"
+    fi
+}
+# Shrinks the ext filesystems inside a supported LVM stack ahead of capture
+# and records how small each LV — and the whole PV partition — could be
+# rebuilt on a deploy target. The LVs themselves are not reduced; partclone
+# only captures the shrunken filesystem's used blocks either way. Layouts
+# probeLVMPartition rejects are demoted to fixed size, which is exactly the
+# Phase 1 behavior.
+# Writes /tmp/<part>.lvmmin: one "LV <name> <minsectors>" line per LV plus
+# "PARTMIN <sectors>", consumed by saveLVMPartition and
+# applyLVMMinimumSizes.
+#
+# $1 = partition device holding the PV
+shrinkLVMPartition() {
+    local part="$1"
+    [[ -z $part ]] && handleError "No partition passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    local part_number=0
+    getPartitionNumber "$part"
+    probeLVMPartition "$part"
+    if [[ -n $lvm_unsupported ]]; then
+        echo " * LVM layout is not supported for per-LV capture: $lvm_unsupported"
+        echo " * Not shrinking ($part) trying fixed size"
+        debugPause
+        echo "$(cat "$imagePath/d1.fixed_size_partitions" | tr -d \\0):${part_number}" > "$imagePath/d1.fixed_size_partitions"
+        return
+    fi
+    local vggroup="$lvm_vggroup"
+    dots "Activating volume group ($vggroup)"
+    vgchange -ay "$vggroup" >/dev/null 2>&1
+    checkStatus $? "done" "Could not activate volume group $vggroup (${FUNCNAME[0]})\n   Args Passed: $*"
+    udevadm settle >/dev/null 2>&1
+    debugPause
+    local extentsize=$(vgs --noheadings --units s --nosuffix -o vg_extent_size "$vggroup" 2>/dev/null | awk '{printf("%d",$1)}')
+    local pestart=$(pvs --noheadings --units s --nosuffix -o pe_start "$part" 2>/dev/null | awk '{printf("%d",$1)}')
+    [[ -z $extentsize || $extentsize -lt 1 ]] && handleError "Could not read extent size of $vggroup (${FUNCNAME[0]})\n   Args Passed: $*"
+    local minfile="/tmp/${part##*/}.lvmmin"
+    echo -n "" > "$minfile"
+    local totalextents=0
+    local lvname=""
+    local lvsize=""
+    local minsectors=0
+    while read -r lvname lvsize; do
+        [[ -z $lvname ]] && continue
+        lvsize=${lvsize%.*}
+        local lvdev="/dev/${vggroup}/${lvname}"
+        [[ ! -e $lvdev ]] && handleError "Logical volume device missing: $lvdev (${FUNCNAME[0]})\n   Args Passed: $*"
+        local fstype=""
+        fsTypeSetting "$lvdev"
+        minsectors=$lvsize
+        if [[ $fstype == extfs ]]; then
+            dots "Checking $fstype volume ($lvdev)"
+            e2fsck -fp $lvdev >/tmp/e2fsck.txt 2>&1
+            checkStatus $? "done" "e2fsck failed to check $lvdev (${FUNCNAME[0]})\n   Info: $(cat /tmp/e2fsck.txt)\n   Args Passed: $*"
+            debugPause
+            local extminsize=$(resize2fs -P $lvdev 2>/dev/null | awk -F': ' '{print $2}')
+            local block_size=$(dumpe2fs -h $lvdev 2>/dev/null | awk '/^Block[ ]size:/{print $3}')
+            local size=$(calculate "${extminsize}*${block_size}")
+            local sizeadd=$(calculate "${percent}/100*${size}")
+            local sizeextresize=$(calculate "${size}+${sizeadd}")
+            [[ -z $sizeextresize || $sizeextresize -lt 1 ]] && handleError "Error calculating the minimum size of extfs ($lvdev) (${FUNCNAME[0]})\n   Args Passed: $*"
+            dots "Shrinking $fstype volume ($lvdev)"
+            resize2fs $lvdev -M >/tmp/resize2fs.txt 2>&1
+            checkStatus $? "done" "Could not shrink $fstype volume ($lvdev) (${FUNCNAME[0]})\n   Info: $(cat /tmp/resize2fs.txt)\n   Args Passed: $*"
+            debugPause
+            dots "Checking $fstype volume ($lvdev)"
+            e2fsck -fp $lvdev >/tmp/e2fsck.txt 2>&1
+            case $? in
+                0)
+                    echo "Done"
+                    ;;
+                *)
+                    e2fsck -fy $lvdev >>/tmp/e2fsck.txt 2>&1
+                    if [[ $? -gt 0 ]]; then
+                        echo "Failed"
+                        debugPause
+                        handleError "Could not check shrunken volume ($lvdev) (${FUNCNAME[0]})\n   Info: $(cat /tmp/e2fsck.txt)\n   Args Passed: $*"
+                    fi
+                    echo "Done"
+                    ;;
+            esac
+            debugPause
+            # ceil to sectors; calculate() rounds, which could go under
+            minsectors=$(( (sizeextresize + 511) / 512 ))
+            [[ $minsectors -gt $lvsize ]] && minsectors=$lvsize
+        else
+            echo " * Not shrinking ($lvdev $fstype)"
+            debugPause
+        fi
+        echo "LV $lvname $minsectors" >> "$minfile"
+        totalextents=$(( totalextents + (minsectors + extentsize - 1) / extentsize ))
+    done < <(lvs --noheadings --units s --nosuffix -o lv_name,lv_size "$vggroup" 2>/dev/null)
+    # one spare extent absorbs metadata rounding on the rebuilt target
+    local pvminsectors=$(( pestart + (totalextents + 1) * extentsize ))
+    [[ $pvminsectors -gt $lvm_pvsize ]] && pvminsectors=$lvm_pvsize
+    echo "PARTMIN $pvminsectors" >> "$minfile"
+    vgchange -an "$vggroup" >/dev/null 2>&1 || echo " * Warning: could not deactivate volume group $vggroup"
+}
+# Grows the ext filesystems inside a supported LVM stack out to their LV
+# boundaries. Runs on the source after capture (undoing shrinkLVMPartition)
+# and on the deploy target (claiming space the restore added to the LVs).
+# Layouts probeLVMPartition rejects were captured raw and are skipped.
+#
+# $1 = partition device holding the PV
+expandLVMPartition() {
+    local part="$1"
+    [[ -z $part ]] && handleError "No partition passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    probeLVMPartition "$part"
+    if [[ -n $lvm_unsupported ]]; then
+        echo " * Not expanding ($part) $lvm_unsupported"
+        debugPause
+        return
+    fi
+    local vggroup="$lvm_vggroup"
+    dots "Activating volume group ($vggroup)"
+    vgchange -ay "$vggroup" >/dev/null 2>&1
+    checkStatus $? "done" "Could not activate volume group $vggroup (${FUNCNAME[0]})\n   Args Passed: $*"
+    udevadm settle >/dev/null 2>&1
+    debugPause
+    local lvname=""
+    while read -r lvname; do
+        [[ -z $lvname ]] && continue
+        local lvdev="/dev/${vggroup}/${lvname}"
+        local fstype=""
+        fsTypeSetting "$lvdev"
+        [[ $fstype != extfs ]] && continue
+        dots "Resizing $fstype volume ($lvdev)"
+        e2fsck -fp $lvdev >/tmp/e2fsck.txt 2>&1
+        case $? in
+            0)
+                ;;
+            *)
+                e2fsck -fy $lvdev >>/tmp/e2fsck.txt 2>&1
+                if [[ $? -gt 0 ]]; then
+                    echo "Failed"
+                    debugPause
+                    handleError "Could not check before resize (${FUNCNAME[0]})\n   Info: $(cat /tmp/e2fsck.txt)\n   Args Passed: $*"
+                fi
+                ;;
+        esac
+        resize2fs $lvdev >/tmp/resize2fs.txt 2>&1
+        checkStatus $? "silent" "Could not resize $lvdev (${FUNCNAME[0]})\n   Info: $(cat /tmp/resize2fs.txt)\n   Args Passed: $*"
+        e2fsck -fp $lvdev >/tmp/e2fsck.txt 2>&1
+        case $? in
+            0)
+                echo "Done"
+                ;;
+            *)
+                e2fsck -fy $lvdev >>/tmp/e2fsck.txt 2>&1
+                if [[ $? -gt 0 ]]; then
+                    echo "Failed"
+                    debugPause
+                    handleError "Could not check after resize (${FUNCNAME[0]})\n   Info: $(cat /tmp/e2fsck.txt)\n   Args Passed: $*"
+                fi
+                echo "Done"
+                ;;
+        esac
+        debugPause
+    done < <(lvs --noheadings -o lv_name "$vggroup" 2>/dev/null | awk '{print $1}')
+    vgchange -an "$vggroup" >/dev/null 2>&1 || echo " * Warning: could not deactivate volume group $vggroup"
+}
+# Rewrites each shrunken PV partition's size in the minimum-size sfdisk dump
+# to the PARTMIN shrinkLVMPartition recorded, so the deploy fill engine may
+# scale the partition down to it. Starts are left alone — the fill engine
+# repacks them. A no-op for disks without a shrunken LVM stack.
+#
+# $1 = disk
+# $2 = disk number
+# $3 = image path
+applyLVMMinimumSizes() {
+    local disk="$1"
+    local disk_number="$2"
+    local imagePath="$3"
+    [[ -z $disk ]] && handleError "No disk passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    [[ -z $disk_number ]] && handleError "No disk number passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    [[ -z $imagePath ]] && handleError "No image path passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    local sfdiskminimumpartitionfilename=""
+    sfdiskMinimumPartitionFileName "$imagePath" "$disk_number"
+    local parts=""
+    local part=""
+    getPartitions "$disk"
+    for part in $parts; do
+        local minfile="/tmp/${part##*/}.lvmmin"
+        [[ ! -r $minfile ]] && continue
+        local pvminsectors=$(awk '$1=="PARTMIN"{print $2; exit}' "$minfile")
+        [[ -z $pvminsectors ]] && continue
+        # the dump's size= values are in its own logical sectors, PARTMIN
+        # is 512-byte sectors
+        local secsize=$(awk '$1=="sector-size:"{print $2; exit}' "$sfdiskminimumpartitionfilename")
+        [[ -z $secsize ]] && secsize=512
+        local minsize=$(( (pvminsectors * 512 + secsize - 1) / secsize ))
+        dots "Recording LVM minimum size for ($part)"
+        awk -v part="$part" -v newsize="$minsize" '$1 == part {sub(/size=[[:space:]]*[0-9]+/, "size=" newsize)} {print}' "$sfdiskminimumpartitionfilename" > /tmp/lvmmindump.tmp
+        checkStatus $? "silent" "Could not rewrite minimum partition dump (${FUNCNAME[0]})\n   Args Passed: $*"
+        mv /tmp/lvmmindump.tmp "$sfdiskminimumpartitionfilename"
+        checkStatus $? "done" "Could not replace minimum partition dump (${FUNCNAME[0]})\n   Args Passed: $*"
+        debugPause
+    done
+}
 # Captures an LVM2 PV partition: sidecar metadata plus one image per LV.
 # Unsupported topologies (multi-PV VG, non-linear LVs) fall back to the
 # raw partclone.imager blob — the pre-LVM behavior — with a loud notice.
-# Capture never writes to the source: the VG is only activated read-visible
-# and deactivated again.
+# On resizable captures shrinkLVMPartition has already run; its recorded
+# minimums go into the sidecar so a smaller target can rebuild the stack.
 #
 # $1 = partition device holding the PV
 # $2 = disk number
@@ -2756,21 +2987,12 @@ saveLVMPartition() {
     [[ -z $imagePath ]] && handleError "No image path passed (${FUNCNAME[0]})\n   Args Passed: $*"
     local part_number=0
     getPartitionNumber "$part"
-    vgscan >/dev/null 2>&1
-    local vggroup=$(trim "$(pvs --noheadings -o vg_name "$part" 2>/dev/null)")
-    local pvuuid=$(trim "$(pvs --noheadings -o pv_uuid "$part" 2>/dev/null)")
-    local pvsize=$(pvs --noheadings --units s --nosuffix -o pv_size "$part" 2>/dev/null | awk '{printf("%d",$1)}')
-    local pvcount=$(vgs --noheadings -o pv_count "$vggroup" 2>/dev/null | awk '{printf("%d",$1)}')
-    local unsupported=""
-    if [[ -z $vggroup ]]; then
-        unsupported="no volume group found on the physical volume"
-    elif [[ $pvcount -ne 1 ]]; then
-        unsupported="volume group $vggroup spans $pvcount physical volumes"
-    elif lvs --noheadings -o lv_layout "$vggroup" 2>/dev/null | grep -qv '^[[:space:]]*linear[[:space:]]*$'; then
-        unsupported="volume group $vggroup contains non-linear volumes (thin/RAID/cache/snapshot)"
-    fi
-    if [[ -n $unsupported ]]; then
-        echo " * LVM layout is not supported for per-LV capture: $unsupported"
+    probeLVMPartition "$part"
+    local vggroup="$lvm_vggroup"
+    local pvuuid="$lvm_pvuuid"
+    local pvsize="$lvm_pvsize"
+    if [[ -n $lvm_unsupported ]]; then
+        echo " * LVM layout is not supported for per-LV capture: $lvm_unsupported"
         echo " * Falling back to raw capture of the whole physical volume"
         debugPause
         savePartclone "$part" "$imagePath/d${disk_number}p${part_number}.img" "imager"
@@ -2791,12 +3013,18 @@ saveLVMPartition() {
     debugPause
     local vguuid=$(trim "$(vgs --noheadings -o vg_uuid "$vggroup" 2>/dev/null)")
     local extentsize=$(vgs --noheadings --units s --nosuffix -o vg_extent_size "$vggroup" 2>/dev/null | awk '{printf("%d",$1)}')
-    echo "LVMFORMAT 1" > "$lvmfilename"
-    echo "PV $pvuuid $part $pvsize" >> "$lvmfilename"
+    # non-resizable captures have no minfile: minimums default to the sizes
+    local minfile="/tmp/${part##*/}.lvmmin"
+    local pvminsize=""
+    [[ -r $minfile ]] && pvminsize=$(awk '$1=="PARTMIN"{print $2; exit}' "$minfile")
+    [[ -z $pvminsize ]] && pvminsize=$pvsize
+    echo "LVMFORMAT 2" > "$lvmfilename"
+    echo "PV $pvuuid $part $pvsize $pvminsize" >> "$lvmfilename"
     echo "VG $vggroup $vguuid $extentsize" >> "$lvmfilename"
     local lvname=""
     local lvuuid=""
     local lvsize=""
+    local lvminsize=""
     while read -r lvname lvuuid lvsize; do
         [[ -z $lvname ]] && continue
         local lvdev="/dev/${vggroup}/${lvname}"
@@ -2805,26 +3033,167 @@ saveLVMPartition() {
         fsTypeSetting "$lvdev"
         # A PV nested inside an LV is out of scope; capture that LV raw.
         [[ $fstype == lvm ]] && fstype="imager"
+        lvminsize=""
+        [[ -r $minfile ]] && lvminsize=$(awk -v lv="$lvname" '$1=="LV" && $2==lv {print $3; exit}' "$minfile")
+        [[ -z $lvminsize ]] && lvminsize=${lvsize%.*}
         if [[ $fstype == swap ]]; then
             local swapuuid=$(blkid -po udev "$lvdev" | awk -F= '/FS_UUID=/{print $2}')
-            echo "LV $lvname $lvuuid ${lvsize%.*} $fstype - ${swapuuid:--}" >> "$lvmfilename"
+            echo "LV $lvname $lvuuid ${lvsize%.*} $lvminsize $fstype - ${swapuuid:--}" >> "$lvmfilename"
             echo " * Saving swap volume UUID ($lvdev)"
             debugPause
             continue
         fi
         local lvmlvimagefilename=""
         lvmLVImageFileName "$imagePath" "$disk_number" "$part_number" "$lvname"
-        echo "LV $lvname $lvuuid ${lvsize%.*} $fstype ${lvmlvimagefilename##*/} -" >> "$lvmfilename"
+        echo "LV $lvname $lvuuid ${lvsize%.*} $lvminsize $fstype ${lvmlvimagefilename##*/} -" >> "$lvmfilename"
         echo " * Processing Logical Volume: $lvdev ($fstype)"
         debugPause
         savePartclone "$lvdev" "$lvmlvimagefilename" "$fstype"
     done < <(lvs --noheadings --units s --nosuffix -o lv_name,lv_uuid,lv_size "$vggroup" 2>/dev/null)
     vgchange -an "$vggroup" >/dev/null 2>&1 || echo " * Warning: could not deactivate volume group $vggroup"
 }
-# Recreates and restores an LVM2 stack captured by saveLVMPartition. Runs
+# Grows a restored volume group into a target partition larger than the
+# original PV: pvresize claims the new space, then the free extents are
+# spread across the non-swap LVs proportionally to their original sizes —
+# the same policy the fill engine applies to partitions. Swap LVs keep
+# their original size. Filesystems grow later, in expandLVMPartition.
+# Format-2 sidecars only.
+#
+# $1 = partition device holding the PV
+# $2 = volume group
+# $3 = sidecar file
+growLVMPartition() {
+    local part="$1"
+    local vggroup="$2"
+    local lvmfilename="$3"
+    [[ -z $lvmfilename ]] && handleError "No sidecar file passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    dots "Growing physical volume ($part)"
+    pvresize "$part" >/dev/null 2>&1
+    checkStatus $? "done" "Could not grow physical volume on $part (${FUNCNAME[0]})\n   Args Passed: $*"
+    debugPause
+    local freeextents=$(vgs --noheadings -o vg_free_count "$vggroup" 2>/dev/null | awk '{printf("%d",$1)}')
+    [[ $freeextents -lt 1 ]] && return
+    local tag=""
+    local lvname=""
+    local lvuuid=""
+    local lvsize=""
+    local lvminsize=""
+    local lvfstype=""
+    local lvimage=""
+    local swapuuid=""
+    local totalorig=0
+    local lastlv=""
+    while read -r tag lvname lvuuid lvsize lvminsize lvfstype lvimage swapuuid; do
+        [[ $tag != LV || $lvfstype == swap ]] && continue
+        totalorig=$(( totalorig + lvsize ))
+        lastlv=$lvname
+    done < "$lvmfilename"
+    [[ $totalorig -lt 1 ]] && return
+    local usedextents=0
+    local share=0
+    while read -r tag lvname lvuuid lvsize lvminsize lvfstype lvimage swapuuid; do
+        [[ $tag != LV || $lvfstype == swap ]] && continue
+        if [[ $lvname == $lastlv ]]; then
+            share=$(( freeextents - usedextents ))
+        else
+            share=$(( freeextents * lvsize / totalorig ))
+        fi
+        usedextents=$(( usedextents + share ))
+        [[ $share -lt 1 ]] && continue
+        dots "Growing logical volume ($lvname)"
+        lvextend -l +${share} "/dev/${vggroup}/${lvname}" >/dev/null 2>&1
+        checkStatus $? "done" "Could not grow logical volume $lvname (${FUNCNAME[0]})\n   Args Passed: $*"
+        debugPause
+    done < "$lvmfilename"
+}
+# Rebuilds an LVM stack in a target partition smaller than the original PV.
+# vgcfgrestore cannot apply metadata describing more extents than the PV
+# holds, so the stack is recreated with the standard tools instead: each
+# non-swap LV gets its recorded minimum plus a share of the surplus
+# proportional to its original size; swap LVs keep their original size.
+# The PV UUID, VG/LV names, filesystem UUIDs, and swap UUIDs all survive;
+# the VG and LV UUIDs regenerate (docs/adr/0006). Format-2 sidecars only.
+#
+# $1 = partition device to hold the PV
+# $2 = PV UUID to recreate
+# $3 = volume group name
+# $4 = extent size in 512-byte sectors
+# $5 = sidecar file
+rebuildLVMPartition() {
+    local part="$1"
+    local pvuuid="$2"
+    local vggroup="$3"
+    local extentsize="$4"
+    local lvmfilename="$5"
+    [[ -z $lvmfilename ]] && handleError "No sidecar file passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    [[ -z $extentsize || $extentsize -lt 1 ]] && handleError "No extent size in LVM sidecar (${FUNCNAME[0]})\n   Args Passed: $*"
+    dots "Recreating physical volume"
+    pvcreate -ff -y --norestorefile --uuid "$pvuuid" "$part" >/dev/null 2>&1
+    checkStatus $? "done" "Could not recreate physical volume on $part (${FUNCNAME[0]})\n   Args Passed: $*"
+    debugPause
+    dots "Recreating volume group ($vggroup)"
+    vgcreate -y -s "${extentsize}s" "$vggroup" "$part" >/dev/null 2>&1
+    checkStatus $? "done" "Could not recreate volume group $vggroup (${FUNCNAME[0]})\n   Args Passed: $*"
+    debugPause
+    local freeextents=$(vgs --noheadings -o vg_free_count "$vggroup" 2>/dev/null | awk '{printf("%d",$1)}')
+    local tag=""
+    local lvname=""
+    local lvuuid=""
+    local lvsize=""
+    local lvminsize=""
+    local lvfstype=""
+    local lvimage=""
+    local swapuuid=""
+    local totalminextents=0
+    local totalorig=0
+    local lastlv=""
+    while read -r tag lvname lvuuid lvsize lvminsize lvfstype lvimage swapuuid; do
+        [[ $tag != LV ]] && continue
+        if [[ $lvfstype == swap ]]; then
+            totalminextents=$(( totalminextents + (lvsize + extentsize - 1) / extentsize ))
+        else
+            totalminextents=$(( totalminextents + (lvminsize + extentsize - 1) / extentsize ))
+            totalorig=$(( totalorig + lvsize ))
+            lastlv=$lvname
+        fi
+    done < "$lvmfilename"
+    local surplus=$(( freeextents - totalminextents ))
+    [[ $surplus -lt 0 ]] && handleError "Partition $part is too small for the minimum LVM layout ($freeextents extents available, $totalminextents needed) (${FUNCNAME[0]})\n   Args Passed: $*"
+    local usedsurplus=0
+    local share=0
+    local extents=0
+    while read -r tag lvname lvuuid lvsize lvminsize lvfstype lvimage swapuuid; do
+        [[ $tag != LV ]] && continue
+        if [[ $lvfstype == swap ]]; then
+            extents=$(( (lvsize + extentsize - 1) / extentsize ))
+        else
+            if [[ $lvname == $lastlv ]]; then
+                share=$(( surplus - usedsurplus ))
+            else
+                share=$(( surplus * lvsize / totalorig ))
+            fi
+            usedsurplus=$(( usedsurplus + share ))
+            extents=$(( (lvminsize + extentsize - 1) / extentsize + share ))
+        fi
+        dots "Recreating logical volume ($lvname)"
+        lvcreate -y -Wn -Zn -l "$extents" -n "$lvname" "$vggroup" >/dev/null 2>&1
+        checkStatus $? "done" "Could not recreate logical volume $lvname (${FUNCNAME[0]})\n   Args Passed: $*"
+        debugPause
+    done < "$lvmfilename"
+    dots "Activating volume group ($vggroup)"
+    vgchange -ay "$vggroup" >/dev/null 2>&1
+    checkStatus $? "done" "Could not activate volume group $vggroup (${FUNCNAME[0]})\n   Args Passed: $*"
+    udevadm settle >/dev/null 2>&1
+    debugPause
+}
+# Recreates and restores an LVM2 stack captured by saveLVMPartition,
+# dispatching on the target partition's size. Same size or larger runs
 # LVM's own disaster-recovery procedure — pvcreate --restorefile plus
 # vgcfgrestore — so the PV, VG, and every LV come back with their original
-# UUIDs and exact segment layout. Failures are fatal (docs/adr/0003).
+# UUIDs and exact segment layout; a larger target then grows the stack
+# (growLVMPartition). A smaller target rebuilds the stack at the recorded
+# minimums (rebuildLVMPartition) or refuses if it cannot fit. Failures are
+# fatal (docs/adr/0003).
 #
 # $1 = partition device to hold the PV
 # $2 = disk number
@@ -2847,10 +3216,27 @@ restoreLVMPartition() {
     lvmVgcfgFileName "$imagePath" "$disk_number" "$part_number"
     [[ ! -r $lvmvgcfgfilename ]] && handleError "LVM metadata backup missing: $lvmvgcfgfilename (${FUNCNAME[0]})\n   Args Passed: $*"
     local lvmformat=$(head -n 1 "$lvmfilename")
-    [[ $lvmformat != "LVMFORMAT 1" ]] && handleError "Image was captured with a newer LVM format ($lvmformat), update FOS (${FUNCNAME[0]})\n   Args Passed: $*"
+    case $lvmformat in
+        "LVMFORMAT 1"|"LVMFORMAT 2")
+            ;;
+        *)
+            handleError "Image was captured with a newer LVM format ($lvmformat), update FOS (${FUNCNAME[0]})\n   Args Passed: $*"
+            ;;
+    esac
     local pvuuid=$(awk '$1=="PV"{print $2; exit}' "$lvmfilename")
+    local pvsize=$(awk '$1=="PV"{print $4; exit}' "$lvmfilename")
+    local pvminsize=$(awk '$1=="PV"{print $5; exit}' "$lvmfilename")
+    [[ -z $pvminsize ]] && pvminsize=$pvsize
     local vggroup=$(awk '$1=="VG"{print $2; exit}' "$lvmfilename")
-    [[ -z $pvuuid || -z $vggroup ]] && handleError "Incomplete LVM sidecar: $lvmfilename (${FUNCNAME[0]})\n   Args Passed: $*"
+    local extentsize=$(awk '$1=="VG"{print $4; exit}' "$lvmfilename")
+    [[ -z $pvuuid || -z $vggroup || -z $pvsize ]] && handleError "Incomplete LVM sidecar: $lvmfilename (${FUNCNAME[0]})\n   Args Passed: $*"
+    local targetsize=$(blockdev --getsz "$part" 2>/dev/null)
+    [[ -z $targetsize || $targetsize -lt 1 ]] && handleError "Could not read the size of $part (${FUNCNAME[0]})\n   Args Passed: $*"
+    # Refuse before the target is touched.
+    if [[ $targetsize -lt $pvsize ]]; then
+        [[ $lvmformat == "LVMFORMAT 1" ]] && handleError "Target partition $part is smaller than the original physical volume and the image records no LVM minimum sizes; recapture with a current FOS or deploy to a same-size-or-larger disk (${FUNCNAME[0]})\n   Args Passed: $*"
+        [[ $targetsize -lt $pvminsize ]] && handleError "Target partition $part ($targetsize sectors) is smaller than the minimum this image can shrink to ($pvminsize sectors) (${FUNCNAME[0]})\n   Args Passed: $*"
+    fi
     local split=''
     if [[ $imgFormat -eq 6 || $imgFormat -eq 4 || $imgFormat -eq 2 ]]; then
         split='*'
@@ -2860,29 +3246,46 @@ restoreLVMPartition() {
     # A previous life of this target may have left volume groups active;
     # stale device mappings would collide with the names being restored.
     vgchange -an >/dev/null 2>&1
-    dots "Recreating physical volume"
     wipefs -a "$part" >/dev/null 2>&1
-    pvcreate -ff -y --uuid "$pvuuid" --restorefile "$lvmvgcfgfilename" "$part" >/dev/null 2>&1
-    checkStatus $? "done" "Could not recreate physical volume on $part (${FUNCNAME[0]})\n   Args Passed: $*"
-    debugPause
-    dots "Restoring volume group metadata"
-    vgcfgrestore -f "$lvmvgcfgfilename" "$vggroup" >/dev/null 2>&1
-    checkStatus $? "done" "Could not restore volume group metadata of $vggroup (${FUNCNAME[0]})\n   Args Passed: $*"
-    debugPause
-    dots "Activating volume group ($vggroup)"
-    vgchange -ay "$vggroup" >/dev/null 2>&1
-    checkStatus $? "done" "Could not activate volume group $vggroup (${FUNCNAME[0]})\n   Args Passed: $*"
-    udevadm settle >/dev/null 2>&1
-    debugPause
+    if [[ $targetsize -ge $pvsize ]]; then
+        dots "Recreating physical volume"
+        pvcreate -ff -y --uuid "$pvuuid" --restorefile "$lvmvgcfgfilename" "$part" >/dev/null 2>&1
+        checkStatus $? "done" "Could not recreate physical volume on $part (${FUNCNAME[0]})\n   Args Passed: $*"
+        debugPause
+        dots "Restoring volume group metadata"
+        vgcfgrestore -f "$lvmvgcfgfilename" "$vggroup" >/dev/null 2>&1
+        checkStatus $? "done" "Could not restore volume group metadata of $vggroup (${FUNCNAME[0]})\n   Args Passed: $*"
+        debugPause
+        dots "Activating volume group ($vggroup)"
+        vgchange -ay "$vggroup" >/dev/null 2>&1
+        checkStatus $? "done" "Could not activate volume group $vggroup (${FUNCNAME[0]})\n   Args Passed: $*"
+        udevadm settle >/dev/null 2>&1
+        debugPause
+        # format 1 recorded no per-LV originals to distribute by; its extra
+        # space stays unallocated in the VG, exactly as Phase 1 left it
+        if [[ $targetsize -gt $pvsize && $lvmformat == "LVMFORMAT 2" ]]; then
+            growLVMPartition "$part" "$vggroup" "$lvmfilename"
+        fi
+    else
+        rebuildLVMPartition "$part" "$pvuuid" "$vggroup" "$extentsize" "$lvmfilename"
+    fi
     local tag=""
     local lvname=""
     local lvuuid=""
     local lvsize=""
+    local lvminsize=""
     local lvfstype=""
     local lvimage=""
     local swapuuid=""
-    while read -r tag lvname lvuuid lvsize lvfstype lvimage swapuuid; do
+    while read -r tag lvname lvuuid lvsize lvminsize lvfstype lvimage swapuuid; do
         [[ $tag != LV ]] && continue
+        if [[ $lvmformat == "LVMFORMAT 1" ]]; then
+            # format 1 has no minimum-size column; shift the trailing fields
+            swapuuid=$lvimage
+            lvimage=$lvfstype
+            lvfstype=$lvminsize
+            lvminsize=$lvsize
+        fi
         local lvdev="/dev/${vggroup}/${lvname}"
         [[ ! -e $lvdev ]] && handleError "Logical volume missing after restore: $lvdev (${FUNCNAME[0]})\n   Args Passed: $*"
         if [[ $lvfstype == swap ]]; then

--- a/docs/adr/0006-lvm-resize-shrink-capture-grow-deploy.md
+++ b/docs/adr/0006-lvm-resize-shrink-capture-grow-deploy.md
@@ -1,0 +1,112 @@
+# Resize LVM images: shrink LV filesystems at capture, refit the VG at deploy
+
+Phase 1 ([ADR-0004](0004-lvm-per-lv-capture-and-deploy.md)) captures and
+deploys LVM stacks faithfully — but only at their original size. The PV
+partition is pinned in `d1.fixed_size_partitions`, so an LVM image cannot
+deploy to a smaller disk at all, extra space on a larger disk is left
+unallocated, and a disk whose only Linux data partition is the PV fails
+resizable capture with "No resizable partitions found". We decided FOS will
+**shrink each LV's filesystem at capture and record per-LV minimum sizes in
+the sidecar, let the existing sfdisk fill engine scale the PV partition
+between that minimum and the target disk's capacity, and refit the volume
+group to whatever partition size deploy actually produced** — completing the
+Phase 2 scope ADR-0004 reserved.
+
+## Capture: same trust model as plain partitions
+
+Resizable capture already writes to the source machine on every run: ext
+filesystems are shrunk with `resize2fs -M`, partitions are shrunk and
+restored, filesystems re-expanded. LV shrinking is the same procedure run
+against `/dev/<vg>/<lv>` instead of `/dev/sdXN`:
+
+1. `shrinkPartition()` gains an `lvm` case dispatching to
+   `shrinkLVMPartition`. Unsupported topologies (per the ADR-0004 probe,
+   now shared as `probeLVMPartition`) append the partition to
+   `d1.fixed_size_partitions` — the same mid-flight demotion the NTFS
+   failure path uses — and everything behaves exactly as Phase 1.
+2. For each **ext** LV: `e2fsck`, compute minimum via `resize2fs -P` plus
+   the same percent slack the plain-partition path uses, `resize2fs -M`,
+   `e2fsck`. Other filesystems (xfs and f2fs cannot shrink; btrfs-on-LVM is
+   rare enough that shrinking it is not worth the mount dance) and swap
+   keep their original size as their minimum. The LV itself is **not**
+   reduced (`lvreduce` on the source is risk without benefit — partclone
+   captures used blocks of the shrunk filesystem either way).
+3. Minimums are handed to the capture step via `/tmp/<part>.lvmmin`:
+   one line per LV plus a `PARTMIN` line — the PV partition minimum:
+   `pe_start` + every LV's minimum rounded up to whole extents + one spare
+   extent, capped at the original PV size.
+4. After `fog.upload` saves `d1.minimum.partitions`, new helper
+   `applyLVMMinimumSizes` rewrites the PV entry's `size=` in that dump to
+   `PARTMIN` (converted into the dump's logical-sector units). Starts are
+   left alone — the fill engine repacks them at deploy. On disks with no
+   supported PV the helper is a no-op.
+5. The sidecar becomes `LVMFORMAT 2`: the `PV` line gains a minimum-size
+   column and each `LV` line gains a minimum-size column after the size.
+   `mps`/`mpa` captures never run the shrink path, so their format-2
+   sidecars record minimum = original — honestly stating those images only
+   fit same-or-larger targets, which is what those image types mean.
+6. `expandPartition()` gains the matching `lvm` case
+   (`expandLVMPartition`): activate the VG, `resize2fs` each ext LV back to
+   the LV boundary, deactivate. On the source this undoes step 2; on the
+   deploy target it grows each filesystem into its (possibly extended) LV.
+
+With the PV no longer forcibly fixed, fstype `lvm` joins the resizable set
+in `beginUpload`'s classification and partition count — a disk that is only
+EFI + PV now satisfies imgType `n` (`skiplvm=1` still yields fstype
+`imager`, which stays fixed, preserving the escape hatch unchanged).
+
+## Deploy: three cases keyed off the actual partition size
+
+The fill engine sizes the PV partition somewhere between the recorded
+minimum and proportional-fill of the target disk. `restoreLVMPartition`
+compares the actual partition (`blockdev --getsz`, 512-byte sectors — the
+same unit `pvs`/`lvs --units s` report) against the recorded PV size:
+
+- **Equal** — byte-for-byte the Phase 1 path: `pvcreate --uuid
+  --restorefile` + `vgcfgrestore`. Every UUID preserved.
+- **Larger** — Phase 1 path, then `pvresize` to claim the new space and
+  `lvextend` distributing the free extents across non-swap LVs
+  proportionally to their original sizes (the same policy the sfdisk fill
+  engine applies to partitions); swap LVs stay at original size. Every
+  UUID still preserved.
+- **Smaller** — `vgcfgrestore` cannot apply metadata describing more
+  extents than the PV has, so the stack is rebuilt: `pvcreate --uuid`
+  (PV UUID preserved), `vgcreate` with the original extent size,
+  `lvcreate` per LV in sidecar order at minimum-plus-proportional-share
+  sizes. VG and LV UUIDs regenerate; VG/LV **names**, the PV UUID,
+  filesystem UUIDs (partclone restores them), and swap UUIDs (`mkswap
+  -U`) are all preserved, which is what fstab/GRUB/initramfs actually
+  reference. Rebuilding at *computed sizes with real LVM tools* is
+  deliberately chosen over authoring adjusted metadata text for
+  `vgcfgrestore` — hand-edited metadata was CloneDeploy's bug factory.
+  A target below the recorded minimum refuses with a clear message
+  before anything is written.
+
+Deploys of format-1 images keep Phase 1 behavior in every respect: the PV
+is in their `d1.fixed_size_partitions`, so the fill engine never shrinks it
+and `expandPartition` skips it; a format-1 sidecar reaching the
+smaller-target branch anyway refuses, telling the user to recapture with a
+current FOS. Format 2 is refused by Phase 1 FOS builds with the existing
+"captured with a newer LVM format, update FOS" error, so a format-2 image
+can never be half-understood by an older client.
+
+All failure modes stay fatal per
+[ADR-0003](0003-fail-loud-on-partition-table-failure.md) — a proportional
+computation that cannot fit the minimums into the actual VG (`vg_free_count`
+is consulted, not assumed) stops the task rather than truncating an LV.
+
+## Known gaps (deliberate)
+
+- **Only ext filesystems shrink.** xfs/f2fs cannot shrink by design; btrfs
+  and NTFS inside LVs are captured at full size (their minimum = original).
+  They still *grow* on larger targets only in the LV dimension, not the
+  filesystem — growing non-ext filesystems inside LVs can be added to
+  `expandLVMPartition` case-by-case if demand appears.
+- **Swap LVs never resize.** Original size on every target. Grow-with-RAM
+  policies are the admin's job post-deploy.
+- **Smaller targets regenerate VG/LV UUIDs.** Documented behavior of the
+  rebuild path; systems referencing `/dev/mapper/<vg>-<lv>` names or
+  filesystem UUIDs (the norm) are unaffected. Same-or-larger targets keep
+  every UUID.
+- Multi-PV, non-linear, whole-disk-PV, and multicast gaps carry over from
+  ADR-0004 unchanged.

--- a/tests/checks/lvm.sh
+++ b/tests/checks/lvm.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 #
-# Assertion harness for the LVM per-LV capture/deploy path in funcs.sh
-# (docs/adr/0004): saveLVMPartition, restoreLVMPartition, and the dispatch
-# points that route an LVM2_member partition into them.
+# Assertion harness for the LVM per-LV capture/deploy and resize paths in
+# funcs.sh (docs/adr/0004, docs/adr/0006): saveLVMPartition,
+# restoreLVMPartition, shrinkLVMPartition, expandLVMPartition,
+# growLVMPartition, rebuildLVMPartition, applyLVMMinimumSizes, and the
+# dispatch points that route an LVM2_member partition into them.
 #
 #   tests/checks/lvm.sh        # run all cases, exit non-zero on any failure
 #
@@ -30,8 +32,9 @@ sed -e "s#^\. /usr/share/fog/lib/partition-funcs\.sh#. $SANDBOX/partition-funcs.
     "$REPO_LIB/funcs.sh" > "$SANDBOX/funcs.sh"
 # The lvdev rewrite is what lets LV existence checks pass without root; if the
 # source stops matching it, every case below would silently test nothing.
+# (shrinkLVMPartition, expandLVMPartition, saveLVMPartition, restoreLVMPartition)
 rewrites=$(grep -c "lvdev=\"$SANDBOX/dev/" "$SANDBOX/funcs.sh")
-[[ $rewrites -eq 2 ]] || { echo "ERROR: expected 2 lvdev rewrites, got $rewrites (funcs.sh changed shape?)" >&2; exit 2; }
+[[ $rewrites -eq 4 ]] || { echo "ERROR: expected 4 lvdev rewrites, got $rewrites (funcs.sh changed shape?)" >&2; exit 2; }
 
 # --- deterministic stubs for the external tools (via PATH) ---
 STUBBIN="$SANDBOX/bin"
@@ -48,6 +51,7 @@ case $field in
     vg_name) echo "  $FAKE_VG" ;;
     pv_uuid) echo "  $FAKE_PVUUID" ;;
     pv_size) echo "  $FAKE_PVSIZE" ;;
+    pe_start) echo "  $FAKE_PESTART" ;;
 esac
 exit 0
 EOF
@@ -60,6 +64,7 @@ case $field in
     pv_count) echo "  $FAKE_PVCOUNT" ;;
     vg_uuid) echo "  $FAKE_VGUUID" ;;
     vg_extent_size) echo "  $FAKE_EXTENT" ;;
+    vg_free_count) echo "  $FAKE_FREE" ;;
 esac
 exit 0
 EOF
@@ -71,6 +76,8 @@ for a in "$@"; do [[ $prev == "-o" ]] && field="$a"; prev="$a"; done
 case $field in
     lv_layout) printf '%s\n' "$FAKE_LAYOUTS" ;;
     lv_name,lv_uuid,lv_size) printf '%s\n' "$FAKE_LVS" ;;
+    lv_name,lv_size) printf '%s\n' "$FAKE_LVS" | awk '{print "  "$1" "$3}' ;;
+    lv_name) printf '%s\n' "$FAKE_LVS" | awk '{print "  "$1}' ;;
 esac
 exit 0
 EOF
@@ -130,8 +137,47 @@ echo "/dev/sdb3 part"
 exit 0
 EOF
 
+# resize2fs: -P reports the fake minimum block count, everything else is a
+# logged no-op (the shrink/expand calls themselves).
+cat > "$STUBBIN/resize2fs" <<'EOF'
+#!/bin/bash
+echo "resize2fs $*" >> "$CALLS"
+for a in "$@"; do
+    [[ $a == "-P" ]] && { echo "Estimated minimum size of the filesystem: $FAKE_EXTMIN"; break; }
+done
+exit 0
+EOF
+
+# dumpe2fs -h: only the block-size line matters to shrinkLVMPartition.
+cat > "$STUBBIN/dumpe2fs" <<'EOF'
+#!/bin/bash
+echo "dumpe2fs $*" >> "$CALLS"
+echo "Block size:               $FAKE_BLOCKSIZE"
+exit 0
+EOF
+
+# blockdev --getsz is how restoreLVMPartition sizes the deploy target.
+cat > "$STUBBIN/blockdev" <<'EOF'
+#!/bin/bash
+echo "blockdev $*" >> "$CALLS"
+[[ $1 == "--getsz" ]] && echo "$FAKE_PARTSIZE"
+exit 0
+EOF
+
+# lvcreate creates the LV device node like the real tool would, so the
+# restore loop's -e existence check only passes if the rebuild ran first.
+cat > "$STUBBIN/lvcreate" <<'EOF'
+#!/bin/bash
+echo "lvcreate $*" >> "$CALLS"
+name=""; prev=""; vg=""
+for a in "$@"; do [[ $prev == "-n" ]] && name="$a"; prev="$a"; vg="$a"; done
+[[ -n $name && -n $vg ]] && { mkdir -p "$SANDBOX/dev/$vg"; touch "$SANDBOX/dev/$vg/$name"; }
+exit 0
+EOF
+
 # Log-and-succeed doubles for everything else the paths shell out to.
-for tool in vgscan vgchange pvcreate vgcfgrestore wipefs mkswap udevadm umount blockdev usleep; do
+for tool in vgscan vgchange pvcreate vgcfgrestore pvresize lvextend vgcreate \
+            e2fsck wipefs mkswap udevadm umount usleep; do
     printf '#!/bin/bash\necho "%s $*" >> "$CALLS"\nexit 0\n' "$tool" > "$STUBBIN/$tool"
 done
 chmod +x "$STUBBIN"/*
@@ -161,6 +207,11 @@ assert_no_call() { ! grep -qF "$2" "$CALLS" 2>/dev/null && ok "$1" || ko "$1 (un
 
 # Fresh image dir, calls log, fake /dev tree, and a supported default topology
 # (single-PV VG "fakevg" with a linear ext4 root and a swap LV) per case.
+# The default sizes give exact integer arithmetic everywhere: extent size
+# 8192 sectors (4 MiB), root 20971520 (10 GiB), swap 4194304 (2 GiB),
+# PV 41940992 (~20 GiB), pe_start 2048; the minimum ext root is 262144
+# 4 KiB blocks (1 GiB), which at percent=25 shrinks to exactly 2621440
+# sectors (320 extents).
 new_case() {
     IMGDIR="$SANDBOX/img.$1"
     rm -rf "$IMGDIR"
@@ -170,16 +221,21 @@ new_case() {
     rm -rf "$SANDBOX/dev"
     mkdir -p "$SANDBOX/dev/fakevg"
     : > "$SANDBOX/blkid.map"
-    rm -f /tmp/pigz1
+    rm -f /tmp/pigz1 /tmp/sdb3.lvmmin /tmp/lvmmindump.tmp
     FAKE_VG="fakevg"
     FAKE_PVUUID="PVUUID-test"
     FAKE_PVSIZE="41940992.00"
     FAKE_PVCOUNT="1"
     FAKE_VGUUID="VGUUID-test"
     FAKE_EXTENT="8192.00"
+    FAKE_PESTART="2048.00"
     FAKE_LAYOUTS=$'  linear\n  linear'
     FAKE_LVS=$'  root ROOT-uuid 20971520.00\n  swap_1 SWAP-uuid 4194304.00'
     FAKE_SWAPUUID="SWAPUUID-test"
+    FAKE_PARTSIZE="41940992"
+    FAKE_FREE="0"
+    FAKE_EXTMIN="262144"
+    FAKE_BLOCKSIZE="4096"
 }
 
 # Standard supported-source fixtures on top of new_case.
@@ -189,7 +245,8 @@ lvm_source() {
     touch "$SANDBOX/dev/fakevg/root" "$SANDBOX/dev/fakevg/swap_1"
 }
 
-# A captured image set in $IMGDIR, as saveLVMPartition would leave it.
+# A captured image set in $IMGDIR as an older (Phase 1, format 1) FOS left it:
+# no minimum-size columns.
 lvm_image() {
     cat > "$IMGDIR/d1p3.lvm" <<'SIDE'
 LVMFORMAT 1
@@ -203,6 +260,24 @@ SIDE
     touch "$SANDBOX/dev/fakevg/root" "$SANDBOX/dev/fakevg/swap_1"
 }
 
+# A captured image set as a current (format 2) capture with a shrunken root
+# and home leaves it. Minimum extents: root 320, home 128, swap 512; PV
+# minimum = 2048 + (320+128+512+1)*8192 = 7874560 sectors.
+lvm_image2() {
+    cat > "$IMGDIR/d1p3.lvm" <<'SIDE'
+LVMFORMAT 2
+PV PVUUID-test /dev/sdb3 41940992 7874560
+VG fakevg VGUUID-test 8192
+LV root ROOT-uuid 20971520 2621440 extfs d1p3.root.img -
+LV home HOME-uuid 8388608 1048576 extfs d1p3.home.img -
+LV swap_1 SWAP-uuid 4194304 4194304 swap - SWAPUUID-test
+SIDE
+    echo "# fake vgcfg backup" > "$IMGDIR/d1p3.lvm.vgcfg"
+    echo "IMGDATA" > "$IMGDIR/d1p3.root.img"
+    echo "IMGDATA" > "$IMGDIR/d1p3.home.img"
+    touch "$SANDBOX/dev/fakevg/root" "$SANDBOX/dev/fakevg/home" "$SANDBOX/dev/fakevg/swap_1"
+}
+
 # Run $1 with the library sourced and the imaging globals a deploy/capture
 # would have. handleError is overridden AFTER sourcing so a refusal prints
 # ABORT and ends only the case subshell.
@@ -213,6 +288,7 @@ run() {
         export SANDBOX CALLS
         export FAKE_VG FAKE_PVUUID FAKE_PVSIZE FAKE_PVCOUNT FAKE_VGUUID FAKE_EXTENT
         export FAKE_LAYOUTS FAKE_LVS FAKE_SWAPUUID
+        export FAKE_PESTART FAKE_PARTSIZE FAKE_FREE FAKE_EXTMIN FAKE_BLOCKSIZE
         . "$SANDBOX/funcs.sh"
         handleError() { echo "ABORT: $*"; exit 1; }
         imgFormat=5
@@ -221,6 +297,7 @@ run() {
         osid=50
         storage="STUBSTORE"
         img="STUBIMG"
+        percent=25
         eval "$1"
         echo "RETURNED"
     )"
@@ -248,17 +325,18 @@ assert_out "skiplvm=1 maps LVM2_member to imager" "FSTYPE=imager"
 
 # 3. Supported topology through the real savePartition dispatch: exact sidecar
 # schema, vgcfg backup, one image per non-swap LV, swap recorded not imaged,
-# no raw d1p3.img, VG left deactivated.
+# no raw d1p3.img, VG left deactivated. With no minfile (non-resizable
+# capture) every minimum column defaults to the original size.
 new_case 3
 lvm_source
 run 'savePartition /dev/sdb3 1 "$IMGDIR"'
 assert_out "capture completes" "RETURNED"
 cat > "$SANDBOX/expected.lvm" <<'SIDE'
-LVMFORMAT 1
-PV PVUUID-test /dev/sdb3 41940992
+LVMFORMAT 2
+PV PVUUID-test /dev/sdb3 41940992 41940992
 VG fakevg VGUUID-test 8192
-LV root ROOT-uuid 20971520 extfs d1p3.root.img -
-LV swap_1 SWAP-uuid 4194304 swap - SWAPUUID-test
+LV root ROOT-uuid 20971520 20971520 extfs d1p3.root.img -
+LV swap_1 SWAP-uuid 4194304 4194304 swap - SWAPUUID-test
 SIDE
 if diff -u "$SANDBOX/expected.lvm" "$IMGDIR/d1p3.lvm"; then
     ok "sidecar schema is byte-exact"
@@ -307,17 +385,140 @@ run 'saveLVMPartition /dev/sdb3 1 "$IMGDIR"'
 assert_out "nested-PV capture completes" "RETURNED"
 assert_call "nested PV captured with imager" "partclone.imager" "$SANDBOX/dev/fakevg/data"
 assert_out_line=$(grep "^LV data" "$IMGDIR/d1p3.lvm" 2>/dev/null)
-[[ $assert_out_line == "LV data DATA-uuid 8388608 imager d1p3.data.img -" ]] \
+[[ $assert_out_line == "LV data DATA-uuid 8388608 8388608 imager d1p3.data.img -" ]] \
     && ok "nested PV recorded as imager in sidecar" \
     || ko "nested PV sidecar line wrong: '$assert_out_line'"
+
+# ============================================================
+# Capture-side shrink (resizable images, docs/adr/0006)
+# ============================================================
+
+# 15. Shrink through the real shrinkPartition dispatch: the ext LV's
+# filesystem is shrunk and the minfile records the per-LV and PARTMIN
+# minimums. root: 262144 blocks * 4096 = 1 GiB, +25% slack = 2621440
+# sectors; swap is not shrinkable so it keeps 4194304; PARTMIN =
+# 2048 + (320+512+1)*8192 = 6825984.
+new_case 15
+lvm_source
+run 'imagePath="$IMGDIR"; shrinkPartition /dev/sdb3 "$IMGDIR/fstypes" ""'
+assert_out "shrink completes" "RETURNED"
+assert_call "ext LV checked before shrink" "e2fsck" "$SANDBOX/dev/fakevg/root"
+assert_call "ext LV filesystem shrunk" "resize2fs" "$SANDBOX/dev/fakevg/root" "-M"
+assert_no_call "swap LV not shrunk" "resize2fs $SANDBOX/dev/fakevg/swap_1"
+assert_call "VG activated for shrink" "vgchange -ay fakevg"
+assert_call "VG deactivated after shrink" "vgchange -an fakevg"
+cat > "$SANDBOX/expected.lvmmin" <<'MIN'
+LV root 2621440
+LV swap_1 4194304
+PARTMIN 6825984
+MIN
+if diff -u "$SANDBOX/expected.lvmmin" /tmp/sdb3.lvmmin; then
+    ok "minfile records exact per-LV and PARTMIN minimums"
+else
+    ko "minfile differs (see diff above)"
+fi
+
+# 16. Shrink then capture: the minfile's minimums land in the format-2
+# sidecar's minimum columns, byte-exact.
+new_case 16
+lvm_source
+run 'imagePath="$IMGDIR"; shrinkPartition /dev/sdb3 "$IMGDIR/fstypes" ""; savePartition /dev/sdb3 1 "$IMGDIR"'
+assert_out "shrink+capture completes" "RETURNED"
+cat > "$SANDBOX/expected.lvm" <<'SIDE'
+LVMFORMAT 2
+PV PVUUID-test /dev/sdb3 41940992 6825984
+VG fakevg VGUUID-test 8192
+LV root ROOT-uuid 20971520 2621440 extfs d1p3.root.img -
+LV swap_1 SWAP-uuid 4194304 4194304 swap - SWAPUUID-test
+SIDE
+if diff -u "$SANDBOX/expected.lvm" "$IMGDIR/d1p3.lvm"; then
+    ok "shrunken sidecar schema is byte-exact"
+else
+    ko "shrunken sidecar schema differs (see diff above)"
+fi
+
+# 17. Unsupported topology at shrink time: demoted to the fixed-size list
+# (Phase 1 behavior), no minfile, no filesystem touched.
+new_case 17
+FAKE_VG=""
+echo "/dev/sdb3 LVM2_member" > "$SANDBOX/blkid.map"
+echo "1:2" > "$IMGDIR/d1.fixed_size_partitions"
+run 'imagePath="$IMGDIR"; shrinkLVMPartition /dev/sdb3'
+assert_out "unsupported topology is not shrunk" "Not shrinking (/dev/sdb3) trying fixed size"
+assert_out "demotion names the cause" "no volume group found"
+fixedlist=$(cat "$IMGDIR/d1.fixed_size_partitions" 2>/dev/null)
+[[ $fixedlist == "1:2:3" ]] \
+    && ok "PV partition demoted to the fixed-size list" \
+    || ko "fixed-size list wrong: '$fixedlist'"
+assert_no_file "no minfile for unsupported topology" /tmp/sdb3.lvmmin
+assert_no_call "unsupported topology never resizes" "resize2fs"
+
+# 18. applyLVMMinimumSizes rewrites only the PV partition's size in the
+# minimum sfdisk dump (512-byte-sector dump: same unit as PARTMIN).
+new_case 18
+cat > /tmp/sdb3.lvmmin <<'MIN'
+LV root 2621440
+LV swap_1 4194304
+PARTMIN 6825984
+MIN
+cat > "$IMGDIR/d1.minimum.partitions" <<'DUMP'
+label: gpt
+sector-size: 512
+
+/dev/sdb1 : start=2048, size=1048576, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+/dev/sdb3 : start=1050624, size=41940992, type=E6D6D379-F507-44C2-A23C-238F2A3DF928
+DUMP
+run 'applyLVMMinimumSizes /dev/sdb 1 "$IMGDIR"'
+assert_out "minimum-dump rewrite completes" "RETURNED"
+assert_out "rewrite is announced" "Recording LVM minimum size for (/dev/sdb3)"
+grep -q "^/dev/sdb3 : start=1050624, size=6825984," "$IMGDIR/d1.minimum.partitions" \
+    && ok "PV minimum size recorded in the dump" \
+    || ko "PV line not rewritten: '$(grep sdb3 "$IMGDIR/d1.minimum.partitions")'"
+grep -q "^/dev/sdb1 : start=2048, size=1048576," "$IMGDIR/d1.minimum.partitions" \
+    && ok "other partitions left untouched" \
+    || ko "sdb1 line changed: '$(grep sdb1 "$IMGDIR/d1.minimum.partitions")'"
+
+# 19. Same rewrite on a 4096-byte-sector dump: PARTMIN is 512-byte sectors,
+# the dump's size= is in its own logical sectors (6825984/8 = 853248).
+new_case 19
+cat > /tmp/sdb3.lvmmin <<'MIN'
+PARTMIN 6825984
+MIN
+cat > "$IMGDIR/d1.minimum.partitions" <<'DUMP'
+label: gpt
+sector-size: 4096
+
+/dev/sdb3 : start=131328, size=5242624, type=E6D6D379-F507-44C2-A23C-238F2A3DF928
+DUMP
+run 'applyLVMMinimumSizes /dev/sdb 1 "$IMGDIR"'
+grep -q "^/dev/sdb3 : start=131328, size=853248," "$IMGDIR/d1.minimum.partitions" \
+    && ok "PARTMIN converted to the dump's 4096-byte sectors" \
+    || ko "4Kn PV line wrong: '$(grep sdb3 "$IMGDIR/d1.minimum.partitions")'"
+
+# 20. No minfile (nothing was shrunk): the dump is left byte-identical.
+new_case 20
+cat > "$IMGDIR/d1.minimum.partitions" <<'DUMP'
+label: gpt
+sector-size: 512
+
+/dev/sdb3 : start=1050624, size=41940992, type=E6D6D379-F507-44C2-A23C-238F2A3DF928
+DUMP
+cp "$IMGDIR/d1.minimum.partitions" "$SANDBOX/dump.before"
+run 'applyLVMMinimumSizes /dev/sdb 1 "$IMGDIR"'
+assert_out "no-minfile pass completes" "RETURNED"
+assert_not_out "no rewrite announced without a minfile" "Recording LVM minimum size"
+diff -q "$SANDBOX/dump.before" "$IMGDIR/d1.minimum.partitions" >/dev/null \
+    && ok "dump untouched without a minfile" \
+    || ko "dump changed without a minfile"
 
 # ============================================================
 # Deploy
 # ============================================================
 
-# 8. Full dispatch through restorePartition: sidecar present routes to the LVM
-# restore; PV/VG recreated from the backup, LVs restored, swap regenerated
-# with its UUID, VG left deactivated.
+# 8. Full dispatch through restorePartition, format-1 image on a same-size
+# target: sidecar present routes to the LVM restore; PV/VG recreated from
+# the backup, LVs restored, swap regenerated with its UUID, VG left
+# deactivated.
 new_case 8
 lvm_image
 run 'restorePartition /dev/sdb3 1 "$IMGDIR" ""'
@@ -341,7 +542,7 @@ assert_no_call "multicast refusal touches nothing" "pvcreate"
 # 10. A sidecar from a newer FOS (unknown format version) refuses.
 new_case 10
 lvm_image
-sed -i 's/^LVMFORMAT 1$/LVMFORMAT 2/' "$IMGDIR/d1p3.lvm"
+sed -i 's/^LVMFORMAT 1$/LVMFORMAT 3/' "$IMGDIR/d1p3.lvm"
 run 'restoreLVMPartition /dev/sdb3 1 "$IMGDIR" ""'
 assert_out "unknown sidecar format refuses" "ABORT:"
 assert_out "format refusal names the cause" "newer LVM format"
@@ -363,6 +564,126 @@ rm -f "$IMGDIR/d1p3.root.img"
 run 'restoreLVMPartition /dev/sdb3 1 "$IMGDIR" ""'
 assert_out "missing LV image refuses" "ABORT:"
 assert_out "missing-image refusal names the cause" "Logical volume image missing"
+
+# ============================================================
+# Deploy-side resize (docs/adr/0006)
+# ============================================================
+
+# 21. Format-2 image on a same-size target: the exact Phase 1 vgcfgrestore
+# path, no grow, no rebuild.
+new_case 21
+lvm_image2
+run 'restoreLVMPartition /dev/sdb3 1 "$IMGDIR" ""'
+assert_out "same-size deploy completes" "RETURNED"
+assert_call "PV recreated with original UUID from backup" "pvcreate" "--uuid PVUUID-test" "--restorefile"
+assert_call "VG metadata restored" "vgcfgrestore" "fakevg"
+assert_no_call "same-size deploy does not grow the PV" "pvresize"
+assert_no_call "same-size deploy does not extend LVs" "lvextend"
+assert_no_call "same-size deploy does not rebuild the VG" "vgcreate"
+assert_call "home LV restored" "partclone.restore" "$SANDBOX/dev/fakevg/home"
+assert_call "swap regenerated with original UUID" "mkswap" "-U SWAPUUID-test"
+
+# 22. Format-2 image on a larger target: vgcfgrestore first (all UUIDs kept),
+# then the PV grows and the free extents are split among the non-swap LVs
+# proportionally to their original sizes. 1024 free extents at 5:2
+# (root 20971520 : home 8388608) = 731 for root, remainder 293 for home,
+# nothing for swap.
+new_case 22
+lvm_image2
+FAKE_PARTSIZE="50331648"
+FAKE_FREE="1024"
+run 'restoreLVMPartition /dev/sdb3 1 "$IMGDIR" ""'
+assert_out "larger-target deploy completes" "RETURNED"
+assert_call "restored from metadata first" "vgcfgrestore" "fakevg"
+assert_call "PV grown into the target" "pvresize" "/dev/sdb3"
+assert_call "root gets its proportional share" "lvextend" "-l +731" "/dev/fakevg/root"
+assert_call "home takes the remainder" "lvextend" "-l +293" "/dev/fakevg/home"
+if grep "lvextend" "$CALLS" | grep -q "swap_1"; then
+    ko "swap LV must not be grown"
+else
+    ok "swap LV stays at its original size"
+fi
+
+# 23. Format-2 image on a smaller (but big-enough) target: the stack is
+# rebuilt with standard tools at the recorded minimums plus a proportional
+# share of the surplus. 2047 free extents - 960 minimum = 1087 surplus:
+# root 320+776=1096, home 128+311=439, swap keeps its original 512.
+# The LV device nodes are removed first so the case proves lvcreate ran
+# before the restore loop's existence checks.
+new_case 23
+lvm_image2
+rm -f "$SANDBOX/dev/fakevg/root" "$SANDBOX/dev/fakevg/home" "$SANDBOX/dev/fakevg/swap_1"
+FAKE_PARTSIZE="16777216"
+FAKE_FREE="2047"
+run 'restoreLVMPartition /dev/sdb3 1 "$IMGDIR" ""'
+assert_out "smaller-target deploy completes" "RETURNED"
+assert_call "PV recreated with original UUID, no metadata file" "pvcreate" "--norestorefile" "--uuid PVUUID-test"
+assert_call "VG recreated with the original extent size" "vgcreate" "-s 8192s" "fakevg" "/dev/sdb3"
+assert_no_call "rebuild does not apply the oversized metadata" "vgcfgrestore"
+assert_call "root rebuilt at minimum plus its surplus share" "lvcreate" "-l 1096" "-n root"
+assert_call "home rebuilt at minimum plus the remainder" "lvcreate" "-l 439" "-n home"
+assert_call "swap rebuilt at its original size" "lvcreate" "-l 512" "-n swap_1"
+assert_call "root restored into the rebuilt LV" "partclone.restore" "$SANDBOX/dev/fakevg/root"
+assert_call "swap regenerated with original UUID" "mkswap" "-U SWAPUUID-test"
+assert_call "VG deactivated after restore" "vgchange -an fakevg"
+
+# 24. Format-2 image on a target below the recorded minimum: refuse before
+# anything on the disk is touched.
+new_case 24
+lvm_image2
+FAKE_PARTSIZE="6000000"
+run 'restoreLVMPartition /dev/sdb3 1 "$IMGDIR" ""'
+assert_out "below-minimum target refuses" "ABORT:"
+assert_out "refusal names the recorded minimum" "smaller than the minimum this image can shrink to (7874560 sectors)"
+assert_no_call "below-minimum refusal wipes nothing" "wipefs"
+assert_no_call "below-minimum refusal creates nothing" "pvcreate"
+
+# 25. Format-1 image (no recorded minimums) on a smaller target: refuse
+# before anything on the disk is touched.
+new_case 25
+lvm_image
+FAKE_PARTSIZE="16777216"
+run 'restoreLVMPartition /dev/sdb3 1 "$IMGDIR" ""'
+assert_out "format-1 image on smaller target refuses" "ABORT:"
+assert_out "refusal explains the missing minimums" "records no LVM minimum sizes"
+assert_no_call "format-1 refusal wipes nothing" "wipefs"
+
+# 26. Format-1 image on a larger target: restores at the original size and
+# leaves the extra space unallocated (Phase 1 behavior — format 1 has no
+# original sizes to distribute by). Also exercises the 7-field line parse.
+new_case 26
+lvm_image
+FAKE_PARTSIZE="50331648"
+run 'restoreLVMPartition /dev/sdb3 1 "$IMGDIR" ""'
+assert_out "format-1 larger-target deploy completes" "RETURNED"
+assert_call "restored from metadata at original size" "vgcfgrestore" "fakevg"
+assert_no_call "format-1 extra space stays unallocated" "pvresize"
+assert_no_call "format-1 LVs are not grown" "lvextend"
+assert_call "format-1 fields parse after the shuffle" "mkswap" "-U SWAPUUID-test"
+
+# ============================================================
+# Deploy-side expand
+# ============================================================
+
+# 27. expandPartition dispatch: ext LVs are grown out to their LV boundary,
+# swap is untouched, VG left deactivated. (Also runs on the source after
+# capture to undo the shrink.)
+new_case 27
+lvm_source
+run 'expandPartition /dev/sdb3 ""'
+assert_out "expand completes" "RETURNED"
+assert_call "ext LV grown to its boundary" "resize2fs" "$SANDBOX/dev/fakevg/root"
+assert_no_call "swap LV not resized" "resize2fs $SANDBOX/dev/fakevg/swap_1"
+assert_call "VG activated for expand" "vgchange -ay fakevg"
+assert_call "VG deactivated after expand" "vgchange -an fakevg"
+
+# 28. Unsupported topology at expand time (raw-captured PV): skipped loudly.
+new_case 28
+FAKE_VG=""
+echo "/dev/sdb3 LVM2_member" > "$SANDBOX/blkid.map"
+run 'expandPartition /dev/sdb3 ""'
+assert_out "unsupported topology is not expanded" "Not expanding (/dev/sdb3)"
+assert_no_call "unsupported expand never resizes" "resize2fs"
 
 # ============================================================
 # Valid-partition discovery


### PR DESCRIPTION
## Summary

Phase 2 of LVM imaging (design in `docs/adr/0006-lvm-resize-shrink-capture-grow-deploy.md`, building on #120 / ADR-0004). LVM images now deploy to **differently-sized target disks** — Phase 1 required same-size-or-larger and left larger disks unallocated.

### Capture: shrink and record minimums

- `shrinkLVMPartition` shrinks each ext LV's filesystem to its minimum plus the same slack percentage the flat-partition resize path uses, then records per-LV minimums and the PV partition minimum (`PARTMIN`) in a minfile.
- `applyLVMMinimumSizes` folds `PARTMIN` into the minimum sfdisk dump so the partition-layout engine can place a smaller PV partition on small targets (converts 512-byte sectors to the dump's logical sector size).
- The sidecar steps to **LVMFORMAT 2**: `PV` gains a minimum-size column, each `LV` line gains a minimum-size column. Format-1 (Phase 1) images still deploy.
- `expandPartition` re-expands the source machine's LVs after capture, mirroring the flat-partition flow.
- Unsupported topologies (no VG, multi-PV, non-linear LVs) are demoted to the fixed-size list at shrink time — exactly the Phase 1 behavior, announced in the log.
- **imgType n**: a per-LV-capturable PV now counts as a resizable partition, so a disk that is only EFI + PV works with *Single Disk - Resizable*. `skiplvm=1` captures keep the old fixed-size handling automatically.

### Deploy: dispatch on target size vs. original PV size

| Target vs. original | Path |
|---|---|
| Same size | Exact Phase 1 `vgcfgrestore` path — every UUID preserved |
| Larger | `vgcfgrestore`, then `pvresize` + proportional `lvextend` of the free extents across non-swap LVs (weighted by original size); swap stays at its original size |
| Smaller, ≥ recorded minimum | Rebuild with standard `pvcreate`/`vgcreate`/`lvcreate` at per-LV minimums plus proportional surplus. PV UUID, VG/LV names, filesystem UUIDs and swap UUIDs preserved; VG/LV UUIDs regenerate — deliberately **not** authoring adjusted LVM metadata text (the CloneDeploy failure mode) |
| Below minimum | Refuse with the recorded minimum in the message |
| Smaller + format-1 image | Refuse (no minimums recorded); message says to recapture or use a bigger disk |

Both refusals fire **before** `vgchange -an`/`wipefs` — a refused deploy touches nothing on the disk.

## Testing

- `tests/checks/lvm.sh` grows from 45 to **110 assertions**: capture-side shrink (exact minfile contents), shrink→capture sidecar byte-exact diff, minimum-dump rewrite at 512 and 4096-byte sector sizes, grow extent math (+731/+293 proportional split), rebuild extent math (minimums + surplus, device nodes proven created by `lvcreate` before the restore loop's existence checks), both pre-wipe refusals, unsupported-topology demotion, and format-1 compatibility in both directions. All green.
- `tests/checks/sector-size.sh`: 22/22.
- `tests/golden/run.sh`: exit 0 (no new FileName helpers; fixture unchanged).
- Needs real-hardware validation (same status as Phase 1) before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)