### PR TITLE
Multicast deploy of per-LV LVM images (client side)

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -3207,7 +3207,13 @@ restoreLVMPartition() {
     [[ -z $part ]] && handleError "No partition passed (${FUNCNAME[0]})\n   Args Passed: $*"
     [[ -z $disk_number ]] && handleError "No disk number passed (${FUNCNAME[0]})\n   Args Passed: $*"
     [[ -z $imagePath ]] && handleError "No image path passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    [[ $mc == yes ]] && handleError "Multicast deploy of LVM images is not supported yet, deploy unicast (${FUNCNAME[0]})\n   Args Passed: $*"
+    if [[ $mc == yes ]]; then
+        # The sender must emit this partition's LV files in sidecar order
+        # (docs/adr/0007); against an older server the receivers would join
+        # the wrong file's session, so refuse before the target is touched.
+        local servercaps=$(curl -Lks "${web}service/getversion.php?caps=1" 2>/dev/null)
+        [[ $servercaps != *mclvm* ]] && handleError "The FOG server does not support multicast deploy of LVM images; update the server or deploy unicast (${FUNCNAME[0]})\n   Args Passed: $*"
+    fi
     local part_number=0
     getPartitionNumber "$part"
     local lvmfilename=""
@@ -3303,7 +3309,7 @@ restoreLVMPartition() {
         [[ ! $? -eq 0 ]] && handleError "Logical volume image missing: $imgfile (${FUNCNAME[0]})\n   Args Passed: $*"
         echo " * Processing Logical Volume: $lvdev"
         debugPause
-        writeImage "$imgfile" "$lvdev"
+        writeImage "$imgfile" "$lvdev" "$mc"
     done < "$lvmfilename"
     # Leave the stack inactive so the deployed OS boots from a clean state.
     vgchange -an "$vggroup" >/dev/null 2>&1 || echo " * Warning: could not deactivate volume group $vggroup"

--- a/docs/adr/0007-multicast-lvm-sidecar-order-contract.md
+++ b/docs/adr/0007-multicast-lvm-sidecar-order-contract.md
@@ -1,0 +1,110 @@
+# Multicast LVM deploy: the sidecar is the stream-ordering contract
+
+Per-LV LVM images ([ADR-0004](0004-lvm-per-lv-capture-and-deploy.md),
+[ADR-0006](0006-lvm-resize-shrink-capture-grow-deploy.md)) refuse multicast
+deploy — a gap ADR-0004 recorded as deliberate. The refusal exists because
+udpcast synchronizes by nothing but order: the server chains one
+`udp-sender --file <path>;` per image file on a shared portbase, the client
+opens one `udp-receiver` per file it expects, and the Nth receiver gets the
+Nth file. No filename, size, or checksum crosses the wire. Per-LV images add
+a variable number of files per partition, so both sides must agree on the
+sequence or partclone restores one LV's filesystem onto another. We decided
+**both sides derive the stream order from the same `dNpM.lvm` sidecar: the
+server emits each LVM partition's LV image files in sidecar line order where
+the partition's `dNpM.img` would have gone, the client keeps restoring in
+sidecar line order and simply passes the multicast flag through to
+`writeImage`, and a capability probe against `getversion.php` refuses the
+deploy against a server too old to know about per-LV files.**
+
+## What makes this small: multicast already mounts NFS
+
+`fog.download` sources `fog.mount` unconditionally, so multicast clients
+mount the image directory over NFS exactly like unicast ones — that is how
+partition tables, sfdisk dumps, and MBRs already reach multicast deploys.
+Everything `restoreLVMPartition` does besides bulk data — reading the
+sidecar and vgcfg backup, the size refusals, `pvcreate`/`vgcfgrestore`, the
+grow and rebuild paths, `mkswap` — works untouched. Only the partclone
+streams need udpcast, and `writeImage`'s multicast branch already ignores
+its file argument (the path only orders and existence-checks). The client
+change is: delete the refusal, pass `"$mc"` to `writeImage` in the LV loop.
+The existence check on each LV image file stays — it runs against NFS and
+catches a mismatched image before a receiver opens.
+
+Timing needs no care either: all metadata work happens before the
+partition's first receiver opens and between LV restores the loop proceeds
+immediately, well inside udp-sender's 600-second inter-file wait.
+
+## Why sidecar order and not a sort
+
+The alternative is what flat images do: the server `natcasesort()`s the
+filenames and the client iterates partitions in device order, which happens
+to match. Extending that to LV files means FOS replicating PHP's
+case-insensitive natural sort in shell — and any divergence (`Data` vs
+`backup`, `lv2` vs `lv10`, locale collation) is not a crash but a silent
+data-placement bug. Ordering by the sidecar makes divergence structurally
+impossible: both sides read the same lines of the same file, skip the same
+swap and `-` entries, and the client already restores in that order today.
+Overall stream order becomes: disks ascending, partitions ascending (as
+today), LVs in sidecar order within an LVM partition.
+
+## Server change (fogproject, `working-1.6`)
+
+`multicasttask.class.php` currently enumerates with
+`sscanf($filename, 'd1p%d.%s')` keeping only `$ext == 'img'` — because `%s`
+is greedy, `d1p3.root.img` parses as ext `root.img` and per-LV files are
+silently dropped (harmless today only because the client refuses first).
+The rework, in the three branches that enumerate `dNpM` files (image type
+1's DirectoryIterator default branch, type 2, type 3):
+
+- Flat `dNpM.img` files keep sort key (disk, partition, 0). For each
+  `dNpM.lvm` sidecar, parse its `LV` lines and append the named image
+  files under key (disk, partition, LV line index). The image filename is
+  field 7 in an `LVMFORMAT 2` sidecar and field 6 in format 1 — the same
+  header-keyed shift the client does; swap LVs and `-` entries have no
+  file and are skipped by both sides for the same reason.
+- The single-partition filter (`/^d[0-9]p$partid\.img$/`) also admits that
+  partition's LV files.
+- For images with no sidecars the produced order must be **identical** to
+  today's `natcasesort()` output — flat multicast must be provably
+  unchanged.
+
+The multicast manager needs nothing: completion is task-state and
+process-exit driven, not per-file.
+
+## Version skew: refuse, don't hang, never misassign
+
+The dangerous pairing is new FOS against an old server. The old server
+sends nothing for the LVM partition, so unless that partition is the last
+thing restored, the client's first LV receiver joins the session of the
+*next flat partition's* file and partclone writes the wrong filesystem into
+the LV. (Old FOS against a new server merely refuses at the client, as
+today.)
+
+The guard is a capability probe, not a version comparison — version strings
+diverge across betas and backports, and the probe must key on the feature,
+not the release. `getversion.php` is a chain of `isset($_REQUEST[...])`
+branches falling through to `echo FOG_VERSION`; `working-1.6` adds a
+`caps` branch returning a space-separated token list including `mclvm`. In
+`restoreLVMPartition`'s multicast path, before anything touches the target,
+FOS curls `${web}service/getversion.php?caps=1` and refuses with a clear
+"server does not support multicast LVM deploy" unless the response contains
+the token. An old server answers the same query with its version string —
+no token, clean refusal, disk untouched. (The `url` proxy branch in
+`getversion.php` whitelists query keys; `caps` joins `client`/`clientver`
+there so node-to-node forwarding keeps working.)
+
+## Known gaps (deliberate)
+
+- **Split images stay out.** The current enumerator drops `.img.000`
+  split pieces for flat images too — split-file multicast is already
+  unsupported. Per-LV files inherit that; not widened here.
+- **A refusing client stalls the session** (below-minimum target, the
+  capability refusal, sector-size mismatch) until udp-sender's max-wait —
+  pre-existing multicast behavior for any client-side abort, unchanged.
+- **Verification needs a real multicast rig.** The shell harness pins the
+  client behavior and the enumerator can be desk-checked against fixture
+  directories, but the ordering contract is only proven end-to-end by a
+  server and at least two receivers on a shared segment. Ordering bugs are
+  data-placement bugs, so this ships behind the same community-validation
+  bar as ADR-0004/0006 — with the capability probe ensuring the failure
+  mode of every skew pairing is a refusal, not corruption.

--- a/tests/checks/lvm.sh
+++ b/tests/checks/lvm.sh
@@ -164,6 +164,25 @@ echo "blockdev $*" >> "$CALLS"
 exit 0
 EOF
 
+# curl answers the multicast capability probe with the fake server's
+# response (a version string for an old server, a token list for a new one).
+cat > "$STUBBIN/curl" <<'EOF'
+#!/bin/bash
+echo "curl $*" >> "$CALLS"
+printf '%s' "$FAKE_SERVERCAPS"
+exit 0
+EOF
+
+# udp-receiver stands in for the multicast session: writeImage backgrounds it
+# with stdout on the /tmp/pigz1 fifo, so emitting the marker feeds the same
+# decompress-and-restore pipeline the unicast cat path uses.
+cat > "$STUBBIN/udp-receiver" <<'EOF'
+#!/bin/bash
+echo "udp-receiver $*" >> "$CALLS"
+echo "IMGDATA"
+exit 0
+EOF
+
 # lvcreate creates the LV device node like the real tool would, so the
 # restore loop's -e existence check only passes if the rebuild ran first.
 cat > "$STUBBIN/lvcreate" <<'EOF'
@@ -236,6 +255,7 @@ new_case() {
     FAKE_FREE="0"
     FAKE_EXTMIN="262144"
     FAKE_BLOCKSIZE="4096"
+    FAKE_SERVERCAPS="1.6.0"
 }
 
 # Standard supported-source fixtures on top of new_case.
@@ -289,6 +309,7 @@ run() {
         export FAKE_VG FAKE_PVUUID FAKE_PVSIZE FAKE_PVCOUNT FAKE_VGUUID FAKE_EXTENT
         export FAKE_LAYOUTS FAKE_LVS FAKE_SWAPUUID
         export FAKE_PESTART FAKE_PARTSIZE FAKE_FREE FAKE_EXTMIN FAKE_BLOCKSIZE
+        export FAKE_SERVERCAPS
         . "$SANDBOX/funcs.sh"
         handleError() { echo "ABORT: $*"; exit 1; }
         imgFormat=5
@@ -298,6 +319,9 @@ run() {
         storage="STUBSTORE"
         img="STUBIMG"
         percent=25
+        web="http://fogserver/fog/"
+        port=9000
+        storageip="10.0.0.1"
         eval "$1"
         echo "RETURNED"
     )"
@@ -531,13 +555,43 @@ assert_call "root LV restored with partclone" "partclone.restore"
 assert_call "swap LV regenerated with original UUID" "mkswap" "-U SWAPUUID-test" "$SANDBOX/dev/fakevg/swap_1"
 assert_call "VG deactivated after restore" "vgchange -an fakevg"
 
-# 9. Multicast deploy refuses instead of hanging the whole session.
+# 9. Multicast deploy against a server that does not report the mclvm
+# capability (an old server answers the caps probe with its version string):
+# refuse before the target is touched (docs/adr/0007). Without the refusal
+# the LV receivers would join the wrong files' sessions.
 new_case 9
 lvm_image
 run 'restoreLVMPartition /dev/sdb3 1 "$IMGDIR" yes'
-assert_out "multicast LVM deploy refuses" "ABORT:"
-assert_out "multicast refusal names the cause" "Multicast"
-assert_no_call "multicast refusal touches nothing" "pvcreate"
+assert_out "multicast against old server refuses" "ABORT:"
+assert_out "multicast refusal names the cause" "does not support multicast deploy of LVM images"
+assert_call "server capability was probed" "curl" "getversion.php?caps=1"
+assert_no_call "multicast refusal wipes nothing" "wipefs"
+assert_no_call "multicast refusal creates nothing" "pvcreate"
+assert_no_call "multicast refusal opens no receiver" "udp-receiver"
+
+# 29. Multicast deploy against a server reporting mclvm: the metadata work is
+# unchanged (it rides NFS), and the LV loop opens one udp-receiver per
+# non-swap LV — in sidecar line order, the ordering contract of
+# docs/adr/0007 — instead of reading the image files.
+new_case 29
+lvm_image2
+FAKE_SERVERCAPS="mclvm"
+run 'restoreLVMPartition /dev/sdb3 1 "$IMGDIR" yes'
+assert_out "capable-server multicast deploy completes" "RETURNED"
+assert_call "server capability was probed" "curl" "getversion.php?caps=1"
+assert_call "PV still recreated from NFS metadata" "pvcreate" "--uuid PVUUID-test" "--restorefile"
+assert_call "VG metadata still restored over NFS" "vgcfgrestore" "fakevg"
+assert_call "receiver joins the session on the task's portbase" \
+    "udp-receiver" "--portbase 9000" "--mcast-rdv-address 10.0.0.1"
+rcv=$(grep -c '^udp-receiver' "$CALLS")
+[[ $rcv -eq 2 ]] \
+    && ok "one receiver per non-swap LV, none for swap" \
+    || ko "expected 2 udp-receiver calls, got $rcv"
+restored=$(grep '^partclone.restore' "$CALLS" | sed -n 's#.*fakevg/\([a-z_0-9]*\).*#\1#p' | tr '\n' ' ')
+[[ $restored == "root home " ]] \
+    && ok "LVs restored in sidecar line order" \
+    || ko "restore order wrong: '$restored' (want 'root home ')"
+assert_call "swap still regenerated locally, not multicast" "mkswap" "-U SWAPUUID-test"
 
 # 10. A sidecar from a newer FOS (unknown format version) refuses.
 new_case 10


### PR DESCRIPTION
## What

Removes the multicast refusal for per-LV LVM images and replaces it with a server capability probe, per the new [ADR-0007](docs/adr/0007-multicast-lvm-sidecar-order-contract.md) (bundled in this PR).

udpcast synchronizes by nothing but order — the Nth receiver gets the Nth file — so per-LV images need both sides to agree on the file sequence. The contract: **both sides derive the stream order from the `dNpM.lvm` sidecar**. The client already restores in sidecar line order, and multicast already NFS-mounts the image store (that's how sfdisk dumps and MBRs reach multicast deploys today), so all metadata work — sidecar/vgcfg reads, size refusals, grow/rebuild, mkswap — is untouched. The client change is just:

- `restoreLVMPartition` passes `"$mc"` through to `writeImage` in the LV loop, whose existing receiver branch joins the next session on the task's portbase.
- The old refusal becomes a capability probe: the deploy proceeds only if `getversion.php?caps=1` answers with the `mclvm` token. An old server answers with its version string → clean refusal **before the target is touched**. Without this, an old server (which drops per-LV files from its send list) would leave the client's LV receivers joining the *next flat partition's* session — partclone writing the wrong filesystem into the LV.

## Server counterpart

The sender-side rework (emit LV files in sidecar order, plus the `caps` branch in `getversion.php`) lands in fogproject `working-1.6`. Until then, multicast LVM deploys refuse exactly like before — just with a message pointing at the server instead of "not supported yet".

## Testing

`tests/checks/lvm.sh` grows to 121 assertions (all green): curl + udp-receiver stubs, the refusal case reworked into old-server-refuses-pre-wipe, and a capable-server case pinning one receiver per non-swap LV in sidecar line order with metadata still restored over NFS. `sector-size.sh` and `fill-engine.sh` still pass.

End-to-end ordering proof needs a real multicast rig (server + ≥2 receivers) — same community-validation bar as ADR-0004/0006, with the capability probe ensuring every skew pairing fails as a refusal, not corruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)