### PR TITLE
Tell the user they are rate limited instead of blaming the server

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.man.reg
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.man.reg
@@ -327,6 +327,17 @@ while [[ -z $askme ]]; do
                         echo " * Error: Invalid Login! ($retry remaining)"
                         let retry-=1
                         ;;
+                    '#!rl')
+                        # The server rate limits this endpoint after
+                        # repeated bad credentials and answers '#!rl'
+                        # until the window expires. Without this case it
+                        # fell through to "Unexpected response from
+                        # server", which sends the user looking for a
+                        # network fault instead of waiting.
+                        echo
+                        echo " * Error: Too many failed logins. Wait a few minutes and try again."
+                        let retry-=1
+                        ;;
                     *)
                         echo
                         echo " * Error: Unexpected response from server ($retry remaining)"


### PR DESCRIPTION
Server-side half is FOGProject/fogproject#890.

`packages/web/service/checkcredentials.php` answers `#!rl` once the login rate
limit trips, but this `case` only knew `#!ok` and `#!il`. A locked-out user fell
through to the catch-all:

```
 * Error: Unexpected response from server (2 remaining)
```

which reads as a network or server fault. The lockout only clears on a
successful login or when the window expires, so there was nothing on screen to
suggest that waiting is the fix.

## Verified

- `curl -Lks` (what this script uses) has no `-f`, so it prints a 4xx body — the
  `#!rl` body was arriving all along, it just had no case to land in. The
  matching fogproject change drops the `429` so the reply is a plain 200 like
  the other three, but this fix does not depend on that landing first: the body
  is the same either way.
- `bash -n` clean.
- Retry is decremented as `#!il` does, so a locked-out user cannot spin in the
  loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)