### PR TITLE
Let build.sh sign the kernel for Secure Boot

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,13 +20,16 @@ Usage() {
     echo -e "\t\t-i --install-dep (optional) Attempt to install dependencies."
     echo -e "\t\t-v --verbose (optional) Show make output on screen for filesystem builds as well as write it to the log file."
     echo -e "\t\t   --fs-download-only (optional) Only download Buildroot source packages for each filesystem."
+    echo -e "\t\t   --sign-key (optional) Private key used to sign the kernel for UEFI Secure Boot."
+    echo -e "\t\t   --sign-cert (optional) Certificate matching --sign-key. Both are required together."
+    echo -e "\t\t                Can also be given as \$FOS_SIGN_KEY / \$FOS_SIGN_CERT."
     echo -e "\t\t-h --help -? Display this message."
     exit 0
 }
 [[ -n "$arch" ]] && unset "$arch"
 
 shortopts="?hkfnia:p:v"
-longopts="help,kernel-only,filesystem-only,noconfirm,install-dep,arch:,path:,verbose,fs-download-only"
+longopts="help,kernel-only,filesystem-only,noconfirm,install-dep,arch:,path:,verbose,fs-download-only,sign-key:,sign-cert:"
 
 optargs=$(getopt -o "$shortopts" -l "$longopts" -n "$0" -- "$@")
 [[ $? -ne 0 ]] && Usage
@@ -76,6 +79,14 @@ while :; do
             buildPath=$2
             shift 2
             ;;
+        --sign-key)
+            signKey=$2
+            shift 2
+            ;;
+        --sign-cert)
+            signCert=$2
+            shift 2
+            ;;
         --)
             shift
             break
@@ -94,6 +105,28 @@ done
 [[ -z $installDep ]] && installDep="n"
 [[ -z $verbose ]] && verbose="n"
 [[ -z $fsDownloadOnly ]] && fsDownloadOnly="n"
+[[ -z $signKey ]] && signKey="$FOS_SIGN_KEY"
+[[ -z $signCert ]] && signCert="$FOS_SIGN_CERT"
+
+# Signing is entirely opt-in: with neither set, every artifact is produced
+# exactly as it always was. Half a pair is always a mistake, so refuse it rather
+# than silently shipping an unsigned kernel someone believes is signed.
+if [[ -n $signKey || -n $signCert ]]; then
+    if [[ -z $signKey || -z $signCert ]]; then
+        echo "Error: --sign-key and --sign-cert must be given together."
+        Usage
+    fi
+    for f in "$signKey" "$signCert"; do
+        if [[ ! -r $f ]]; then
+            echo "Error: cannot read signing file '$f'."
+            exit 1
+        fi
+    done
+    if ! command -v sbsign >/dev/null 2>&1; then
+        echo "Error: sbsign not found. Install sbsigntool (Debian/Ubuntu) or sbsigntools (RHEL/Fedora)."
+        exit 1
+    fi
+fi
 
 checkDependencies
 installDependencies "$installDep"
@@ -230,6 +263,28 @@ function buildFilesystem() {
     cd ..
 }
 
+# Sign a built kernel in place for UEFI Secure Boot. No-op unless --sign-key and
+# --sign-cert were given. Must run before the artifact is checksummed so the
+# published sha256 covers the signed image, not the one we threw away.
+#
+# sbsign will not cleanly re-sign an already-signed image, so it writes to a
+# temp file and replaces the original only on success. A signing failure is
+# fatal: a build that quietly emits an unsigned kernel is worse than no build,
+# because it fails later at the client with a Security Policy Violation.
+function signKernel() {
+    local kernelfile="$1"
+    [[ -z $signKey ]] && return 0
+    dots "Signing $kernelfile for Secure Boot"
+    if ! sbsign --key "$signKey" --cert "$signCert" \
+            --output "${kernelfile}.signed" "$kernelfile" >/dev/null 2>&1; then
+        echo "Failed"
+        echo " * sbsign could not sign $kernelfile"
+        exit 1
+    fi
+    mv -f "${kernelfile}.signed" "$kernelfile"
+    echo "Done"
+}
+
 function buildKernel() {
     local arch="$1"
     local kflags ktarget
@@ -334,7 +389,7 @@ function buildKernel() {
             kernelfile='arm_Image'
             ;;
     esac
-    [[ ! -f $compiledfile ]] && echo 'File not found.' || cp "$compiledfile" "$kernelfile" && sha256sum "$kernelfile" > "${kernelfile}.sha256"
+    [[ ! -f $compiledfile ]] && echo 'File not found.' || { cp "$compiledfile" "$kernelfile" && signKernel "$kernelfile" && sha256sum "$kernelfile" > "${kernelfile}.sha256"; }
     cd ..
 }
 

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,8 @@ Usage() {
     echo -e "\t\t-v --verbose (optional) Show make output on screen for filesystem builds as well as write it to the log file."
     echo -e "\t\t   --fs-download-only (optional) Only download Buildroot source packages for each filesystem."
     echo -e "\t\t   --sign-key (optional) Private key used to sign the kernel for UEFI Secure Boot."
-    echo -e "\t\t   --sign-cert (optional) Certificate matching --sign-key. Both are required together."
+    echo -e "\t\t   --sign-cert (optional) Certificate matching --sign-key, PEM or DER."
+    echo -e "\t\t                Both are required together."
     echo -e "\t\t                Can also be given as \$FOS_SIGN_KEY / \$FOS_SIGN_CERT."
     echo -e "\t\t-h --help -? Display this message."
     exit 0
@@ -125,6 +126,32 @@ if [[ -n $signKey || -n $signCert ]]; then
     if ! command -v sbsign >/dev/null 2>&1; then
         echo "Error: sbsign not found. Install sbsigntool (Debian/Ubuntu) or sbsigntools (RHEL/Fedora)."
         exit 1
+    fi
+    # sbsign reads certificates with OpenSSL's PEM_read_bio_X509 and rejects
+    # DER outright, while mokutil and MokManager -- the tools that enrol the
+    # same certificate on a client -- want DER. Anyone following the Secure
+    # Boot how-to therefore ends up holding one of each, with nothing telling
+    # them which tool takes which, and handing over the wrong one produces:
+    #
+    #   Can't load certificate from file 'MOK.der'
+    #   error:0480006C:PEM routines:get_name:no start line
+    #
+    # which never mentions the format. Accept either and convert here, so the
+    # flag behaves the way --secure-boot-cert does in the installer.
+    if openssl x509 -in "$signCert" -inform pem -noout >/dev/null 2>&1; then
+        signCertPem="$signCert"
+    else
+        signCertPem=$(mktemp) || { echo "Error: could not create a temporary file."; exit 1; }
+        # The certificate is public, so a world-readable temp file leaks
+        # nothing -- it is the private key beside it that matters. Removed on
+        # exit regardless of how the build ends.
+        trap 'rm -f "$signCertPem"' EXIT
+        if ! openssl x509 -in "$signCert" -inform der -outform pem \
+                -out "$signCertPem" 2>/dev/null; then
+            echo "Error: '$signCert' is not a readable certificate (tried PEM and DER)."
+            exit 1
+        fi
+        echo " * Converted DER certificate '$signCert' to PEM for signing."
     fi
 fi
 
@@ -273,12 +300,22 @@ function buildFilesystem() {
 # because it fails later at the client with a Security Policy Violation.
 function signKernel() {
     local kernelfile="$1"
+    local sberr
     [[ -z $signKey ]] && return 0
     dots "Signing $kernelfile for Secure Boot"
-    if ! sbsign --key "$signKey" --cert "$signCert" \
-            --output "${kernelfile}.signed" "$kernelfile" >/dev/null 2>&1; then
+    # $signCertPem, not $signCert: the latter may be the DER copy the admin
+    # enrols with, which sbsign cannot read. See the conversion above.
+    #
+    # sbsign's stderr is captured rather than discarded. It was going to
+    # /dev/null, which meant the one line explaining WHY signing failed --
+    # unreadable key, wrong passphrase, malformed image -- was thrown away and
+    # the operator got only "could not sign".
+    if ! sberr=$(sbsign --key "$signKey" --cert "$signCertPem" \
+            --output "${kernelfile}.signed" "$kernelfile" 2>&1 >/dev/null); then
         echo "Failed"
         echo " * sbsign could not sign $kernelfile"
+        [[ -n $sberr ]] && sed 's/^/   /' <<<"$sberr"
+        rm -f "${kernelfile}.signed"
         exit 1
     fi
     mv -f "${kernelfile}.signed" "$kernelfile"


### PR DESCRIPTION
Companion to [FOGProject/fogproject#961](https://github.com/FOGProject/fogproject/pull/961) (server-side signing and the enrolment kit) and the guide rewrite in [FOGProject/fog-docs](https://github.com/FOGProject/fog-docs). This is the piece for people who build FOS themselves rather than using the released kernels.

## The problem

FOS kernels ship unsigned, so a site running UEFI Secure Boot has to sign them itself. Doing that after the fact means the published `.sha256` no longer matches the file anyone actually boots, and it has to be redone by hand on every build.

## What changed

`--sign-key` / `--sign-cert` (or `FOS_SIGN_KEY` / `FOS_SIGN_CERT`, which is easier in CI) `sbsign` the artifact in `buildKernel()` **between** the copy into `dist/` and the `sha256sum`, so the published hash covers the signed image.

With neither set the build is byte-for-byte what it was. Half a pair is refused rather than silently producing an unsigned kernel someone believes is signed — that failure would otherwise surface much later, at a client, as a `Security Policy Violation` with nothing on the server to explain it. A signing failure is fatal for the same reason.

## Drive-by fix

Grouping the finalize step also fixes a latent bug. The old chain:

```bash
[[ ! -f $compiledfile ]] && echo 'File not found.' || cp ... && sha256sum ...
```

parses as `((A && B) || C) && D`, so when the compiled kernel was missing it printed `File not found.` and **then still ran `sha256sum`**, writing an empty `.sha256` for a file that was not there. Reproduced against the original line before changing it. `buildFilesystem()` has the same shape, but it is untouched here — out of scope for this change.

## Verified

- `bash -n build.sh`.
- The finalize line exercised in a sandbox with a stubbed `sbsign` across three cases: no key produces a byte-identical artifact and a checksum that verifies; with a key the artifact is signed and the checksum covers the **signed** file; a missing compiled kernel now produces neither file.

## Not verified

No kernel was compiled — the signing step is verified in isolation, not through a real `./build.sh -nka x64`. Worth one real build with a throwaway key before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZ2jZ7qgen6pXrbtmxShaw

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZ2jZ7qgen6pXrbtmxShaw)_