### PR TITLE
Source the USB image's iPXE binaries from the fog-ipxe release

### DIFF
--- a/create-usb-image.sh
+++ b/create-usb-image.sh
@@ -10,6 +10,15 @@ if [ -z "$dl_url" ]; then
     exit 1
 fi
 
+# Which FOG server branch the memdisk/memtest binaries and the iPXE version pin
+# are read from. Overridable so a stick can be built to match a 1.6 server.
+fog_branch="${FOG_BRANCH:-dev-branch}"
+fp_raw="https://github.com/FOGProject/fogproject/raw/refs/heads/${fog_branch}/packages"
+ipxe_url="https://github.com/FOGProject/fog-ipxe/releases/download"
+# Only used if the version pin cannot be read; keep in step with fogproject's
+# FOG_IPXE_VERSION when bumping it there.
+ipxe_fallback="v2.0.0-fog.2"
+
 if [ -f /tmp/fogkern.img ]; then
     echo Nuking old FOG Debug image
     rm -f /tmp/fos-usb.img
@@ -37,10 +46,37 @@ grub-install --removable --no-nvram --no-uefi-secure-boot --efi-directory=/mnt -
 echo Download the FOG kernels and inits
 wget -P /mnt/boot/ ${dl_url}/bzImage
 wget -P /mnt/boot/ ${dl_url}/init.xz
-wget -P /mnt/boot/ https://github.com/FOGProject/fogproject/raw/refs/heads/dev-branch/packages/web/service/ipxe/memdisk
-wget -P /mnt/boot/ https://github.com/FOGProject/fogproject/raw/refs/heads/dev-branch/packages/web/service/ipxe/memtest.bin
-wget -P /mnt/boot/ https://github.com/FOGProject/fogproject/raw/refs/heads/dev-branch/packages/tftp/ipxe.krn
-wget -P /mnt/boot/ https://github.com/FOGProject/fogproject/raw/refs/heads/dev-branch/packages/tftp/ipxe.efi
+wget -P /mnt/boot/ ${fp_raw}/web/service/ipxe/memdisk
+wget -P /mnt/boot/ ${fp_raw}/web/service/ipxe/memtest.bin
+
+echo Download the iPXE binaries for the Jumpstart menu entries
+# ipxe.krn and ipxe.efi used to be committed to fogproject at packages/tftp/.
+# iPXE now lives in its own repository and ships as a release tarball, so
+# packages/tftp is a gitignored staging directory the FOG installer fills at
+# runtime -- fetching those two paths from git returns 404, and because this
+# script runs under `set -e` that aborted the whole build. Take them from the
+# same release asset the installer uses, pinned to the same version the FOG
+# server pins, so a stick built here chains the iPXE build its server expects.
+# See fogproject GH-959.
+ipxe_ver=$(wget -qO- ${fp_raw}/web/lib/fog/system.class.php \
+    | awk -F"'" '/FOG_IPXE_VERSION/{print $4}' | tr -d '[:space:]')
+if [ -z "$ipxe_ver" ]; then
+    echo "Could not read FOG_IPXE_VERSION from ${fog_branch}, using ${ipxe_fallback}" >&2
+    ipxe_ver="$ipxe_fallback"
+fi
+echo "Using iPXE ${ipxe_ver}"
+
+ipxe_tar="fog-ipxe-${ipxe_ver}.tar.gz"
+ipxe_tmp=$(mktemp -d)
+# Checksum the tarball rather than trusting the transfer. A truncated download
+# would otherwise produce a stick that looks built and fails to boot.
+wget -P "$ipxe_tmp" "${ipxe_url}/${ipxe_ver}/${ipxe_tar}"
+wget -P "$ipxe_tmp" "${ipxe_url}/${ipxe_ver}/${ipxe_tar}.sha256"
+(cd "$ipxe_tmp" && sha256sum -c "${ipxe_tar}.sha256")
+# The tarball is the whole TFTP staging tree; the USB menu only needs the two
+# top-level binaries that grub entries 7 and 8 boot.
+tar -xzf "${ipxe_tmp}/${ipxe_tar}" -C /mnt/boot/ ./ipxe.krn ./ipxe.efi
+rm -rf "$ipxe_tmp"
 
 cat > /mnt/boot/README.txt << 'EOF'
 


### PR DESCRIPTION
Follow-up to #129, which chained `make_usb.yml` into both release workflows so the USB image actually gets built. That part is right — GitHub does not fire `release: published` for releases created by `GITHUB_TOKEN`, so the workflow genuinely never ran.

But the job it wired up would have failed on every release, for a reason that predates that PR.

## The problem

`create-usb-image.sh` fetched four files out of `fogproject`. Two of them no longer exist:

```
web/service/ipxe/memdisk       200
web/service/ipxe/memtest.bin   200
tftp/ipxe.krn                  404
tftp/ipxe.efi                  404
```

iPXE moved to `FOGProject/fog-ipxe` and now ships as a release tarball, which turned `packages/tftp/` into a gitignored staging directory the installer fills at runtime (fogproject GH-959). The `blob/` → `raw/` fix in #129 was correct and necessary, but these two paths are gone from git entirely, on both `dev-branch` and `working-1.6`.

The script runs under `set -e`, so those 404s abort it. The release itself still publishes — `add_usb_image` runs after — but the job goes red and no image is produced. They feed grub menu entries 7 and 8, the iPXE Jumpstart options.

## The fix

Take `ipxe.krn` and `ipxe.efi` from the same release asset the FOG installer uses, pinned to the same `FOG_IPXE_VERSION` the server pins. A stick built here then chains the iPXE build its server expects, rather than whatever happened to be committed at the time.

The tarball is verified against its published `.sha256`. The installer does the same, and the failure it prevents is a truncated download producing a stick that looks built and does not boot.

Also replaces the four repeated hardcoded `dev-branch` URLs with a `$FOG_BRANCH` override (default unchanged), so a stick can be built to match a 1.6 server.

## Verification

Ran the new download block standalone against a temp directory:

```
Using iPXE v2.0.0-fog.2
fog-ipxe-v2.0.0-fog.2.tar.gz: OK

memdisk        Linux kernel x86 boot executable, bzImage, version MEMDISK
memtest.bin    ISO 9660 CD-ROM filesystem data 'MT501' (bootable)
ipxe.krn       Linux kernel x86 boot executable, bzImage, version 2.0.0
ipxe.efi       PE32+ executable for EFI (application), x86-64
```

All four are the right shape for the grub entry that boots them — `ipxe.krn` a bzImage for `linux16`, `ipxe.efi` a PE32+ EFI application for `chainloader`.

Also confirmed the version-pin fallback survives `set -e`: the scrape ends in a pipe to `tr`, and `pipefail` is not set, so a failed fetch yields an empty value and the explicit empty-check handles it rather than aborting.

Payload is 43.7 MB (bzImage 10.5, init.xz 30.0, iPXE + memtest 3.2) into a 128 MB image, so there is ample headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)