### PR TITLE
Make the USB workflow runnable on demand, and survivable on a runner

### DIFF
--- a/.github/workflows/make_usb.yml
+++ b/.github/workflows/make_usb.yml
@@ -9,6 +9,15 @@ on:
       tag_name:
         required: true
         type: string
+  # Lets the image be rebuilt for a release that already exists, without
+  # cutting a new one -- useful when the build is changed, or when a release
+  # predates the workflow being wired up.
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Existing release tag to build the USB image for
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -19,14 +28,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set tag name
         run: echo "TAG_NAME=${{ inputs.tag_name || github.event.release.tag_name }}" >> "$GITHUB_ENV"
 
       - name: Create USB Image
         run: |
-            sudo apt-get install grub-efi-amd64 parted kpartx
+            # -y and an update first: the runner has no tty, so an unattended
+            # apt-get would hit the confirm prompt, read EOF and abort.
+            sudo apt-get update
+            sudo apt-get install -y grub-efi-amd64 parted kpartx
             sudo ./create-usb-image.sh "https://github.com/${{ github.repository }}/releases/download/${{ env.TAG_NAME }}"
 
       - name: Release


### PR DESCRIPTION
Follow-up to #129 and #132. Three problems that had never been exercised, because `make_usb.yml` had never actually run — GitHub does not fire `release: published` for a release created by `GITHUB_TOKEN`, so until #129 chained it in, nothing ever invoked it.

**`apt-get` would abort.** No `-y`, and no `apt-get update` first. A runner has no tty, so the confirm prompt reads EOF and the step fails before the script is even reached.

**`actions/checkout@v2`** — Node 16, while the two release workflows that call this one are already on v4 and v6.

**No manual trigger.** Added `workflow_dispatch` with a `tag_name` input, so the image can be rebuilt for a release that already exists without cutting a new one. That is needed to test the build at all, and it also covers every release published before the workflow was wired up — including the current one.

`${{ inputs.tag_name || github.event.release.tag_name }}` already resolves correctly for `workflow_dispatch`, since dispatch inputs land in the same `inputs` context as `workflow_call`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)