### PR TITLE
Detect a certificate already in db from the bytes, not mokutil's text (GH-134)

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/secureboot-funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/secureboot-funcs.sh
@@ -119,18 +119,62 @@ sbCertFingerprint() {
     [[ -z $cert ]] && handleError "No certificate passed (${FUNCNAME[0]})\n   Args Passed: $*"
     sha256sum "$cert" 2>/dev/null | awk '{print toupper($1)}' | sed 's/../&:/g;s/:$//'
 }
+# Return 0 if the certificate is present in the platform's db.
+#
+# Reads the variable and looks for the certificate's own bytes, rather than
+# asking a tool and parsing what it prints. A db entry embeds the DER verbatim
+# inside an EFI_SIGNATURE_LIST, so "are these bytes in that variable" is exactly
+# the question, and the answer depends only on the UEFI data format -- which is
+# a published spec that cannot quietly change under us. Every alternative here
+# is a bet on some program's output formatting.
+#
+# $1 path to the DER certificate
+sbCertInDb() {
+    local cert="$1"
+    [[ -z $cert ]] && handleError "No certificate passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    local path="${sbEfiVarDir}/db-${sbEfiSecurityGuid}"
+    [[ -r $path && -s $cert ]] || return 1
+    local certhex dbhex
+    # -v because od collapses repeated lines into "*" by default, which would
+    # silently drop a run of identical bytes out of the middle of either string.
+    certhex=$(od -An -tx1 -v "$cert" 2>/dev/null | tr -d '[:space:]')
+    dbhex=$(od -An -tx1 -v "$path" 2>/dev/null | tr -d '[:space:]')
+    [[ -n $certhex && -n $dbhex ]] || return 1
+    case $dbhex in
+        *"$certhex"*) return 0 ;;
+    esac
+    return 1
+}
 # Return 0 if the certificate is already trusted by this machine.
 #
-# Checks the MOK list and db both: a machine that went through the Phase 2 db
-# path has the key in db and no MOK entry at all, and staging a MOK request on
-# it would send a technician to a blue screen for no reason.
+# Two stores, because a machine can be trusting this certificate by either
+# route: the Setup Mode path puts it in db with no MOK entry at all, and the
+# staged-MOK path puts it in MokList with nothing in db. Missing either one
+# sends a technician to a blue screen to re-enrol something already trusted.
+#
+# THIS FUNCTION GOT IT WRONG ONCE, AND ONLY HARDWARE CAUGHT IT. It used to grep
+# `mokutil --db` for the certificate's SHA-256. mokutil prints a **SHA1**
+# fingerprint there, so the match could never fire -- and the harness stub had
+# been written to emit the SHA-256 this code was looking for, so the test agreed
+# with the bug. On a machine whose db already held the certificate, the task
+# went on to stage a MOK anyway, which mokutil then refused (it will not stage a
+# request for a certificate already in db) and the task aborted.
+#
+# Hence: the db half is answered from the bytes (sbCertInDb) rather than from
+# any tool's output, and the MokList half matches mokutil's own strings, taken
+# from the binary rather than assumed -- `mokutil --test-key` reports
+# "<file> is already in db" or "CA of <file> is already enrolled", never the
+# bare "already enrolled" this used to look for. Verified against mokutil 0.7.2,
+# which is what Buildroot builds.
 #
 # $1 path to the DER certificate
 sbCertTrusted() {
     local cert="$1"
     [[ -z $cert ]] && handleError "No certificate passed (${FUNCNAME[0]})\n   Args Passed: $*"
-    mokutil --test-key "$cert" 2>/dev/null | grep -qi "already enrolled" && return 0
-    mokutil --db 2>/dev/null | grep -qiF "$(sbCertFingerprint "$cert" | tr -d ':')" && return 0
+    sbCertInDb "$cert" && return 0
+    case $(mokutil --test-key "$cert" 2>/dev/null) in
+        *"is already in db"*|*"is already enrolled"*) return 0 ;;
+    esac
     return 1
 }
 # Stage a MOK enrolment request, without prompting.

--- a/docs/adr/0009-secure-boot-enrolment-paths.md
+++ b/docs/adr/0009-secure-boot-enrolment-paths.md
@@ -255,17 +255,48 @@ it current.
 - 32-bit UEFI gets no MOK path: no signed 32-bit shim exists (already noted in
   `_enrollSecureBootChoice`). Path 1 would still work there.
 
-## Not yet validated on hardware
+## Hardware validation
 
-Writing `PK`/`KEK`/`db` is not reversible from the OS — getting it wrong needs a
-firmware trip to recover. Path 1 wants per-model hardware validation before it is
-relied on. The staged-MOK path is reversible (`mokutil --revoke-import`) and has
-now been exercised end to end.
+**Path 1 validated end to end on 2026-08-03** (VirtualBox 7.2 EFI, platform keys
+cleared to enter Setup Mode). The task enrolled with nobody at the keyboard, and
+the firmware afterwards held exactly what it should:
 
-What the 40 harness cases can and cannot prove is worth stating plainly, because
-this ADR already recorded one design that passed every test and was still wrong.
-They prove the **bytes and the sequence**: the right namespace, the right
+- `db` — Microsoft's five db CAs plus FOG's signing certificate
+- `KEK` — Microsoft's two KEK CAs plus this server's KEK
+- `PK` — this server's PK alone
+
+Secure Boot was then switched **on**, and the same machine PXE-booted FOG's
+signed chain: `bzImage... ok`, `init.xz... ok`, where before enrolment both were
+refused with `Verification failed: Security Policy Violation`. That is the whole
+feature demonstrated in one line.
+
+Still open: per-model validation on physical firmware. Writing `PK`/`KEK`/`db` is
+not reversible from the OS, so a model that rejects the update needs a firmware
+trip to recover.
+
+### What the harness can and cannot prove
+
+Worth stating plainly, because this ADR has now recorded **two** things that
+passed every test and were still wrong.
+
+The cases prove the **bytes and the sequence**: the right namespace, the right
 attribute mask, one write, `PK` last, no writes after a failed download, and a
 refusal when `SetupMode` does not flip. They cannot prove that a given firmware
-*accepts* the update — that is a property of the machine, not of this code, and
-the only way to learn it is to boot one.
+*accepts* the update — that is a property of the machine.
+
+They also cannot prove that an external tool's output looks the way this code
+assumes. `sbCertTrusted()` used to grep `mokutil --db` for the certificate's
+SHA-256; mokutil prints a **SHA1** fingerprint there, so the match could never
+fire. The stub in the harness had been written to emit the SHA-256 the code was
+looking for, so **the test agreed with the bug** and reported success for a
+fortnight. On the first machine whose `db` already held the certificate, the task
+skipped its short-circuit, tried to stage a MOK, was refused by mokutil (which
+will not stage a request for a certificate already in `db`), and aborted.
+
+The fix is a rule, not a patch: **answer from the data where a spec defines it,
+and from the tool only where the tool owns the format.** db membership is now
+decided by searching the variable for the certificate's own bytes — the UEFI
+signature-list layout is published and cannot drift. MokList membership still
+goes through `mokutil`, but against strings read out of the binary rather than
+imagined. See also the `test-doubles-from-source` note: a double built from a
+guess is a second copy of the guess, not a check on it.

--- a/tests/checks/secureboot.sh
+++ b/tests/checks/secureboot.sh
@@ -75,10 +75,19 @@ case "$1" in
         [[ -f $SANDBOX/staged ]] && echo "[key 1]"
         ;;
     --test-key)
-        [[ -n $FAKE_KEY_ENROLLED ]] && echo "SHA256 ... is already enrolled"
-        ;;
-    --db)
-        echo "${FAKE_DB_OUT:-nothing here}"
+        # VERBATIM mokutil 0.7.2 output. Taken from the format strings in the
+        # binary, NOT invented: an earlier version of this stub printed a
+        # SHA-256 and the phrase "is already enrolled", which is what
+        # sbCertTrusted was grepping for -- so the stub and the bug agreed with
+        # each other and the case passed while the real thing failed on
+        # hardware. If this ever needs changing, read it out of mokutil again.
+        if [[ -n $FAKE_KEY_ENROLLED ]]; then
+            echo "CA of $2 is already enrolled"
+        elif [[ -n $FAKE_KEY_IN_DB ]]; then
+            echo "$2 is already in db"
+        else
+            echo "$2 is not enrolled"
+        fi
         ;;
 esac
 exit 0
@@ -197,6 +206,33 @@ make_firmware() {
     return 0
 }
 
+# Build a db variable holding $1 inside an EFI_SIGNATURE_LIST, the way firmware
+# stores it: 4-byte efivarfs attribute prefix, then a 16-byte EFI_CERT_X509_GUID,
+# SignatureListSize, SignatureHeaderSize(0), SignatureSize, then a 16-byte owner
+# GUID followed by the DER. Built out of the real layout rather than a
+# placeholder, because the code under test searches for the certificate's bytes
+# and a fake shape would prove nothing.
+make_db_with_cert() {
+    local cert="$1"
+    local dir="$SANDBOX/sys/firmware/efi/efivars"
+    local guid="d719b2cb-3d3a-4596-a3bc-dad00e67656f"
+    mkdir -p "$dir"
+    local certsz sigsz listsz
+    certsz=$(stat -c %s "$cert")
+    sigsz=$((certsz + 16))
+    listsz=$((sigsz + 28))
+    {
+        printf '\x27\x00\x00\x00'
+        printf '\xa1\x59\xc0\xa5\xe4\x94\xa7\x4a\x87\xb5\xab\x15\x5c\x2b\xf0\x72'
+        printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' \
+            $((listsz & 255)) $(((listsz >> 8) & 255)) $(((listsz >> 16) & 255)) $(((listsz >> 24) & 255)))"
+        printf '\x00\x00\x00\x00'
+        printf "$(printf '\\x%02x\\x%02x\\x%02x\\x%02x' \
+            $((sigsz & 255)) $(((sigsz >> 8) & 255)) $(((sigsz >> 16) & 255)) $(((sigsz >> 24) & 255)))"
+        printf '\x44\xe4\x62\xf0\xc9\x51\xe8\x41\x8e\xa3\xd4\x40\x7a\xe3\x8e\x04'
+        cat "$cert"
+    } > "$dir/db-$guid"
+}
 # Run a snippet against the sandboxed library and echo its stdout.
 lib() {
     (
@@ -223,12 +259,12 @@ check() {
 
 new_case() {
     FAKE_GENHASH_FAIL=""; FAKE_GENHASH_GARBAGE=""; FAKE_IMPORT_FAIL=""
-    FAKE_IMPORT_NOOP=""; FAKE_KEY_ENROLLED=""; FAKE_DB_OUT=""
+    FAKE_IMPORT_NOOP=""; FAKE_KEY_ENROLLED=""; FAKE_KEY_IN_DB=""
     FAKE_CURL_BODY="der"; FAKE_MOUNT_FAIL=""; FAKE_UNMOUNTED=""
     FAKE_AUTH_FAIL=""; FAKE_DD_FAIL=""; FAKE_PK_KEEPS_SETUP=""
     FAKE_AUTH_GARBAGE=""
     export FAKE_GENHASH_FAIL FAKE_GENHASH_GARBAGE FAKE_IMPORT_FAIL \
-           FAKE_IMPORT_NOOP FAKE_KEY_ENROLLED FAKE_DB_OUT FAKE_CURL_BODY \
+           FAKE_IMPORT_NOOP FAKE_KEY_ENROLLED FAKE_KEY_IN_DB FAKE_CURL_BODY \
            FAKE_MOUNT_FAIL FAKE_UNMOUNTED FAKE_AUTH_FAIL FAKE_DD_FAIL \
            FAKE_PK_KEEPS_SETUP FAKE_AUTH_GARBAGE
     rm -f "$SANDBOX/calls" "$SANDBOX/staged" "$SANDBOX/.mokpwhash" >/dev/null 2>&1
@@ -325,13 +361,37 @@ new_case; make_firmware 0 1; FAKE_KEY_ENROLLED=1; export FAKE_KEY_ENROLLED
 check "already-enrolled MOK is detected" \
     "$(lib 'sbCertTrusted "$SANDBOX/fp.der" && echo trusted || echo untrusted')" "trusted"
 
-# 15. A machine enrolled through the Phase 2 db path has NO MOK entry, so the
-# MOK check alone would wrongly stage a request on it.
+# 15. THE REGRESSION THIS FILE EXISTS FOR. A machine enrolled through the Setup
+# Mode path has the certificate in db and NO MOK entry at all. This case passed
+# for a fortnight against a stub that printed the SHA-256 the (wrong) code was
+# grepping for; mokutil actually prints a SHA1 there, so on real hardware the
+# task went on to stage a MOK, which mokutil refused because the certificate was
+# already in db, and the task aborted.
+#
+# So this now answers the question the way the firmware does: put the
+# certificate's real bytes inside a real EFI_SIGNATURE_LIST in a real db
+# variable, and require sbCertTrusted to find them. mokutil is told the key is
+# NOT enrolled, so only the db path can satisfy it.
 new_case; make_firmware 0 1
-printf '\x30\x82\x01\x0a' > "$SANDBOX/fp.der"
-FAKE_DB_OUT="$(sha256sum "$SANDBOX/fp.der" | awk '{print toupper($1)}')"; export FAKE_DB_OUT
-check "key present in db (no MOK entry) is detected as trusted" \
+printf '\x30\x82\x01\x0a\xde\xad\xbe\xef' > "$SANDBOX/fp.der"
+make_db_with_cert "$SANDBOX/fp.der"
+check "15. certificate present in db (no MOK entry) is detected as trusted" \
     "$(lib 'sbCertTrusted "$SANDBOX/fp.der" && echo trusted || echo untrusted')" "trusted"
+
+# 15b. mokutil's own db verdict is the fallback for firmware whose db this code
+# cannot read directly. Matched on the string mokutil really prints.
+new_case; make_firmware 0 1; FAKE_KEY_IN_DB=1; export FAKE_KEY_IN_DB
+check "15b. mokutil \"is already in db\" is honoured" \
+    "$(lib 'sbCertTrusted "$SANDBOX/fp.der" && echo trusted || echo untrusted')" "trusted"
+
+# 15c. A DIFFERENT certificate in db must not read as trusted -- otherwise the
+# byte search is matching something incidental rather than this certificate.
+new_case; make_firmware 0 1
+printf '\x30\x82\x01\x0a\xde\xad\xbe\xef' > "$SANDBOX/other.der"
+make_db_with_cert "$SANDBOX/other.der"
+printf '\x30\x82\x01\x0a\xca\xfe\xba\xbe' > "$SANDBOX/fp.der"
+check "15c. a different certificate in db does not read as trusted" \
+    "$(lib 'sbCertTrusted "$SANDBOX/fp.der" && echo trusted || echo untrusted')" "untrusted"
 
 # 16. Neither list -> not trusted.
 new_case; make_firmware 0 1


### PR DESCRIPTION
Follow-up to #135, found by running the Setup Mode path on real firmware.

## The bug

`sbCertTrusted()` grepped `mokutil --db` for the certificate's **SHA-256**. mokutil prints a **SHA1** fingerprint there, so the match could never fire.

That is not a cosmetic miss. On a machine the Setup Mode path had just enrolled, the certificate *is* in `db` — so the task skipped its "already trusted, nothing to do" short-circuit, went on to stage a MOK, and mokutil refused (it will not stage a request for a certificate already in `db`). The task then aborted:

```
* Checking firmware state.....................enforcing
* Fetching certificate........................Done
* Certificate SHA-256:
    4A:6B:7C:23:44:17:C0:C5:...
* Staging MOK enrolment request...............Failed
  The MOK enrolment request was NOT staged. (/bin/fog.enrollsb)
```

Anyone re-running the task against an already-enrolled fleet would have watched every host fail.

## Why the tests did not catch it

The harness stub for `mokutil --db` had been written to emit the SHA-256 the broken code was looking for. **The stub and the bug were the same guess**, so case 15 passed and would have kept passing forever. Running the tests more times was never going to find this.

## The fix is a rule, not a patch

Answer from the data where a spec defines it, and from the tool only where the tool owns the format.

- **db membership** → `sbCertInDb()` reads the `db` variable and looks for the certificate's own bytes. A db entry embeds the DER verbatim inside an `EFI_SIGNATURE_LIST`, so this depends only on the published UEFI layout and cannot drift. (`od -v` — without it `od` collapses repeated lines to `*` and would silently drop a run of identical bytes out of the middle of either string.)
- **MokList membership** → still `mokutil`, but matching the strings the binary actually contains: `<file> is already in db` and `CA of <file> is already enrolled`, never the bare `already enrolled` this used to look for. Read out of mokutil 0.7.2, not assumed.

## Tests

The stub now emits mokutil's real output verbatim, with a comment saying where it came from and to go read it again rather than invent it.

- **15** rebuilt to construct a real `EFI_SIGNATURE_LIST` around a real certificate, so it asks the question the firmware asks.
- **15b** covers mokutil's own db verdict.
- **15c** proves a *different* certificate in db does **not** read as trusted, so the byte search cannot pass by matching something incidental.

Reverting `sbCertTrusted()` to the shipped version now fails 15 and 15b. 42 cases pass; golden fixture unchanged.

## Re-verified on hardware

Same VM, certificate in `db`, Secure Boot enforcing: the task completes and leaves no `MokNew`/`MokAuth` behind — it short-circuits instead of staging.

ADR-0009 records the rule, because this is now the second design in that file that passed every test and was still wrong.