### PR TITLE
Publish a checksum for the USB image, and pin/declare the rest

### DIFF
--- a/.github/workflows/create_experimental_release.yml
+++ b/.github/workflows/create_experimental_release.yml
@@ -389,6 +389,12 @@ jobs:
 
     if: needs.release.result == 'success' && inputs.kernel_x64 && inputs.init_x64
 
+    # Granted explicitly rather than inherited -- see the matching block in
+    # create_release.yml. A called workflow is capped by its caller's
+    # permissions, and with no block here that cap is the repo-wide default.
+    permissions:
+      contents: write
+
     uses: ./.github/workflows/make_usb.yml
     with:
       tag_name: ${{ needs.release.outputs.tag_name }}

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -383,6 +383,16 @@ jobs:
 
     if: needs.release.result == 'success'
 
+    # Granted explicitly rather than inherited. A called workflow can never hold
+    # more permission than its caller, so make_usb.yml's own `contents: write`
+    # is capped by whatever this workflow has -- and with no block here that is
+    # the repo-wide default. It is `write` today, so this changes nothing; if
+    # that default is ever tightened to read-only (a common org-wide hardening)
+    # the USB upload would start failing at the very end of a release, after
+    # every build had already succeeded.
+    permissions:
+      contents: write
+
     uses: ./.github/workflows/make_usb.yml
     with:
       tag_name: ${{ needs.release.outputs.tag_name }}

--- a/.github/workflows/make_usb.yml
+++ b/.github/workflows/make_usb.yml
@@ -22,13 +22,32 @@ on:
 permissions:
   contents: write
 
+# One USB build per release tag. Nothing can collide today: the release
+# published by create_release.yml is created with GITHUB_TOKEN, and a release
+# created that way deliberately does not re-trigger workflows, so the
+# `release: published` trigger and the `workflow_call` path never both fire.
+# That protection is real but invisible, and it disappears the moment the
+# release step uses a PAT -- at which point two runs would build and upload the
+# same asset to the same tag at once. Stating it here costs nothing and does not
+# depend on remembering why it was safe.
+concurrency:
+  group: make-usb-${{ inputs.tag_name || github.event.release.tag_name }}
+  cancel-in-progress: false
+
 jobs:
   add-usb-image:
-    runs-on: ubuntu-latest
+    # Pinned rather than ubuntu-latest, matching the two release workflows.
+    # `latest` moves under you between runs, which is exactly the kind of
+    # surprise a release path should not carry.
+    runs-on: ubuntu-24.04
+
+    # A successful run takes well under a minute; this only catches a hang,
+    # which would otherwise sit for the 6 hour default.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set tag name
         run: echo "TAG_NAME=${{ inputs.tag_name || github.event.release.tag_name }}" >> "$GITHUB_ENV"
@@ -41,8 +60,26 @@ jobs:
             sudo apt-get install -y grub-efi-amd64 parted kpartx
             sudo ./create-usb-image.sh "https://github.com/${{ github.repository }}/releases/download/${{ env.TAG_NAME }}"
 
+      # Every other published artifact ships a .sha256 beside it -- build.sh
+      # writes one for each kernel and init, and the release job verifies the
+      # whole set with `sha256sum -c`. The USB image was the exception, and it
+      # is the one asset a user writes straight to physical media, so it is the
+      # one where a silently truncated or corrupted download matters most.
+      #
+      # Generated from inside /tmp so the file records a bare filename, the same
+      # way build.sh does it. `sha256sum -c` then works in whatever directory
+      # someone downloads the pair into; an absolute path would only verify on
+      # a machine that happened to put it in /tmp.
+      - name: Checksum USB image
+        run: |
+            cd /tmp
+            sha256sum fos-usb.img > fos-usb.img.sha256
+            cat fos-usb.img.sha256
+
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.TAG_NAME }}
-          files: /tmp/fos-usb.img
+          files: |
+            /tmp/fos-usb.img
+            /tmp/fos-usb.img.sha256


### PR DESCRIPTION
Follow-up to #137, which left `make_usb.yml` as the last unpinned surface in the repo.

**The USB image had no checksum.** `build.sh` writes a `.sha256` beside every kernel and init, and the `release` job verifies the whole set with `sha256sum -c`. `fos-usb.img` was the exception — and it is the one artifact a user writes straight to physical media, so it is where a silently truncated or corrupted download costs the most. Now published as `fos-usb.img.sha256`, generated from inside `/tmp` so it records a bare filename exactly the way `build.sh` does; an absolute path would only verify for someone who happened to download it to `/tmp`.

**Pinned to match the release workflows:** `ubuntu-latest` → `ubuntu-24.04`, `checkout@v4` → `@v6`, `action-gh-release@v1` → `@v3`. `latest` silently moves between runs, which is not something a release path should carry.

**Permissions are now declared, not inherited.** A called workflow can never hold more permission than its caller, so `make_usb.yml`'s own `contents: write` is capped by whatever the caller has — and neither caller declared a `permissions:` block, leaving it on the repo-wide default. I checked: that default is `write`, so this is a no-op today. It stops being a no-op if the default is ever tightened to read-only (a common org-wide hardening), which would break the upload at the very end of a release, after every build had already succeeded.

**Concurrency group keyed on the release tag.** Nothing can collide today, because a release created with `GITHUB_TOKEN` deliberately does not re-trigger workflows — so the `release: published` trigger and the `workflow_call` path never both fire. That protection is real but invisible, and it disappears the moment the release step uses a PAT, at which point two runs would build and upload the same asset to the same tag simultaneously.

**`timeout-minutes: 30`.** A successful run takes under a minute (the 2026-08-02 run took 43s); this only bounds a hang that would otherwise hold a runner for the 6-hour default.

No change to the build itself, the release name/tag formats, or the existing asset list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsG8G5CPezfAFFsYiXavEK