### PR TITLE
Serialize official release runs

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -17,6 +17,25 @@ defaults:
   run:
     shell: bash
 
+# Only one official release build at a time. The tag is date-based
+# ($(date '+%Y%m%d'), or $fog_version for an official release), so two runs
+# started on the same day target the SAME tag and upload the SAME asset
+# filenames -- bzImage, init.xz and the rest. Re-firing after a failure while
+# the first run still has jobs finishing is the realistic way into that, and it
+# would race two sets of uploads onto one release.
+#
+# cancel-in-progress is deliberately false: a second click must never kill a
+# ~50-minute build that may already be uploading. The second run queues instead,
+# which also makes an accidental double-fire visible in the Actions tab rather
+# than silent.
+#
+# Note this serializes, it does not dedupe -- the queued run still publishes to
+# the same tag when its turn comes. Refusing outright when a tag already exists
+# would be a guard in the release job, not here.
+concurrency:
+  group: create-release
+  cancel-in-progress: false
+
 jobs:
   input_checks:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Adds a workflow-level concurrency group to `create_release.yml`.

Its tag is date-based — `$(date '+%Y%m%d')`, or `$fog_version` for an official release — so two runs started on the same day target the **same tag** and upload the **same asset filenames** (`bzImage`, `init.xz`, …). The realistic way in is re-firing after a failure while the first run still has jobs finishing, which would race two sets of uploads onto one release. The 2026-08-03 double-fire (22:15, then 22:17) was only harmless because the first died in `input_checks` in 30 seconds.

```yaml
concurrency:
  group: create-release
  cancel-in-progress: false
```

`cancel-in-progress: false` is deliberate — a second click must never kill a ~50-minute build that may already be uploading. The second run queues instead, which also makes an accidental double-fire visible in the Actions tab rather than silent.

**This serializes, it does not dedupe.** The queued run still publishes to the same tag when its turn comes. Refusing outright when a tag already exists would be a guard in the `release` job, and is a separate decision.

**`create_experimental_release.yml` deliberately gets no equivalent:** its tag is `EXP_%Y%m%d-%H%M%S` so no two runs can collide on a release, its per-arch ccache keys use `github.run_id`, and concurrent writers of the shared `buildroot-dl` cache are handled by `actions/cache` itself (first finisher wins, the rest emit a warning, not a failure). A group there would serialize two builds for no benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsG8G5CPezfAFFsYiXavEK