### PR TITLE
Refuse Secure Boot enrolment on 32-bit UEFI (GH-140)

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.enrollsb
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.enrollsb
@@ -27,6 +27,26 @@ case $state in
         ;;
 esac
 
+# 32-bit UEFI is refused outright rather than degraded to the db path. See
+# docs/adr/0009-secure-boot-enrolment-paths.md and FOGProject/fos#140.
+#
+# The db write would succeed -- nothing in it is architecture-specific -- and
+# that is precisely the trap. No Microsoft-signed 32-bit shim and no signed
+# 32-bit iPXE exist, so this machine cannot boot FOG under Secure Boot
+# enforcement whether or not the certificate is enrolled. Meanwhile the only
+# state where this task can run on ia32 at all is Setup Mode (nothing is
+# enforcing, so the unsigned chain boots), and the last thing the db path does
+# is write the PK -- which is what LEAVES Setup Mode. Degrading would therefore
+# take a machine FOG can image today, make it enforceable, and leave it with
+# nothing signed to boot, irreversibly from the client's side.
+#
+# Checked before the certificate fetch and before the already-trusted
+# short-circuit: no db contents make enrolment useful here, so there is no state
+# in which continuing tells the admin something more useful than this does.
+if [[ $(sbPlatformBits) == 32 ]]; then
+    handleError "This machine has 32-bit UEFI firmware, which FOG cannot enrol. ($0)\n   No Microsoft-signed 32-bit shim and no signed 32-bit iPXE exist, so it\n   cannot boot FOG under Secure Boot enforcement even with this key trusted.\n   Nothing was enrolled and nothing was changed. Leave Secure Boot off here."
+fi
+
 dots "Fetching certificate"
 if ! sbFetchCert "$cert"; then
     echo "Failed"

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/secureboot-funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/secureboot-funcs.sh
@@ -86,6 +86,39 @@ sbState() {
     [[ $sb == 1 ]] && { echo "enforcing"; return 0; }
     echo "disabled"
 }
+# Echo the width of the UEFI firmware in bits: "32", "64" or "unknown".
+#
+# This is FIRMWARE width, not CPU width, and the distinction is the whole point:
+# ia32 UEFI overwhelmingly runs on 64-bit CPUs (Bay Trail and Cherry Trail
+# tablets are the common case), so `uname -m` answers a different question and
+# answers this one wrongly. fw_platform_size is the firmware's own declaration.
+#
+# Why FOS cares at all: no Microsoft-signed 32-bit shim and no signed 32-bit
+# iPXE exist, so there is no Secure Boot chain an ia32 machine can boot. See the
+# refusal in bin/fog.enrollsb for what that means for enrolment.
+#
+# The kernel has exposed fw_platform_size on every EFI boot since 4.14 and FOS
+# runs 6.x, so on UEFI it is always readable. "unknown" therefore means a BIOS
+# boot -- which sbState() has already caught by the time anything asks -- or
+# something unforeseen. Callers should proceed on "unknown" rather than refuse:
+# guessing wrong in that direction breaks x86-64 clients, which is the far more
+# expensive mistake.
+sbPlatformBits() {
+    local path="/sys/firmware/efi/fw_platform_size"
+    local bits=""
+    # The readability test is what keeps a BIOS boot quiet. Reading a missing
+    # file leaves $bits empty and would reach "unknown" through the wildcard
+    # below anyway, but bash writes "No such file or directory" to stderr on the
+    # way -- and on a BIOS-booted client that is a scary-looking line under a
+    # task that is behaving correctly.
+    [[ -r $path ]] || { echo "unknown"; return 0; }
+    read -r bits < "$path"
+    case $bits in
+        32|64) echo "$bits" ;;
+        *) echo "unknown" ;;
+    esac
+    return 0
+}
 # Download the server's Secure Boot certificate to $1.
 #
 # The certificate is public by design -- it is the thing the server publishes

--- a/docs/adr/0009-secure-boot-enrolment-paths.md
+++ b/docs/adr/0009-secure-boot-enrolment-paths.md
@@ -252,8 +252,30 @@ it current.
   confirmed against real firmware: the attribute mask on `SetupMode` is `0x06`
   (BS|RT, no NV bit), i.e. these variables are volatile and readable only from a
   booted OS — which is why detection lives in FOS and not on the server.
-- 32-bit UEFI gets no MOK path: no signed 32-bit shim exists (already noted in
-  `_enrollSecureBootChoice`). Path 1 would still work there.
+- **32-bit UEFI is refused outright, not degraded to path 1** (FOGProject/fos#140).
+  An earlier revision of this ADR said "no MOK path, but path 1 would still work
+  there". The write would indeed work — nothing in it is architecture-specific —
+  and that is the trap. There is no signed 32-bit boot chain in existence to
+  make bootable: `ipxe/shim` publishes `shimx64.efi` and `shimaa64.efi` only,
+  iPXE's `ipxeboot.tar.gz` ships `x86_64-sb/` and `arm64-sb/` only, and what FOG
+  serves an ia32 client is an unsigned `i386-efi/snponly.efi`.
+
+  The consequence is worse than "no benefit". The one state in which this task
+  can run on ia32 at all is Setup Mode — no PK, so nothing enforces and the
+  unsigned chain boots — and the final act of path 1 is writing the `PK`, which
+  is what *leaves* Setup Mode. Degrading would take a machine FOG can image
+  today, make it enforceable, leave it with nothing signed to load, and `PK` is
+  not reversible from the OS. `sbPlatformBits()` reads
+  `/sys/firmware/efi/fw_platform_size` (firmware width, not `uname -m` — ia32
+  UEFI is usually a 64-bit CPU) and `fog.enrollsb` refuses before fetching
+  anything.
+
+  This would change if FOG signed its own `i386-efi/ipxe.efi` with the key it
+  already writes into `db`: once that certificate is in `db` the firmware
+  accepts a FOG-signed binary directly, with no shim in the path, because shim
+  exists only to bridge to Microsoft's trust and that bridge is redundant here.
+  Nothing builds or signs an ia32 iPXE today, so the refusal means "no chain
+  exists yet", not "ia32 is unsupportable".
 
 ## Hardware validation
 

--- a/tests/checks/secureboot.sh
+++ b/tests/checks/secureboot.sh
@@ -196,6 +196,11 @@ make_firmware() {
     [[ $1 == noefi ]] && return 0
     local dir="$SANDBOX/sys/firmware/efi/efivars"
     mkdir -p "$dir"
+    # $3 is the firmware width the kernel reports. Defaults to 64 so every case
+    # written before this existed keeps meaning exactly what it meant; "-"
+    # models firmware whose size the kernel did not expose at all.
+    local bits="${3:-64}"
+    [[ $bits != - ]] && echo "$bits" > "$SANDBOX/sys/firmware/efi/fw_platform_size"
     local guid="8be4df61-93ca-11d2-aa0d-00e098032b8c"
     # efivarfs layout: 4-byte LE attribute mask, then the data. Writing the
     # prefix is the point -- a reader that forgets it gets the attributes back
@@ -326,6 +331,49 @@ check "sbEfiFlag skips the 4-byte attribute prefix" "$(lib 'sbEfiFlag SetupMode'
 # 9. An absent variable is not an error -- firmware need not expose every one.
 new_case; make_firmware - 1
 check "absent SetupMode -> falls through to SecureBoot" "$(lib 'sbState')" "enforcing"
+
+# --- firmware width ---
+#
+# What these prove is only that the value is read correctly. The refusal itself
+# lives in bin/fog.enrollsb alongside the nonefi and noefivars refusals, which
+# are equally out of this harness's reach -- it sources the library, not the
+# entry point. And per the note at the foot of this file, no case here can prove
+# anything about what a given firmware does.
+
+# 9a. The ordinary case. Every other case in this file relies on this default,
+# so a regression that made 64-bit read as anything else would refuse enrolment
+# on the hardware the feature is actually for.
+new_case; make_firmware 1 0 64
+check "fw_platform_size 64 -> 64" "$(lib 'sbPlatformBits')" "64"
+
+# 9b. ia32 UEFI. This is the answer bin/fog.enrollsb refuses on, because no
+# signed 32-bit shim or iPXE exists for such a machine to boot -- so enrolling
+# would leave it enforceable with nothing signed to load. Note this is firmware
+# width, NOT CPU width: the hardware here is usually a 64-bit CPU, which is why
+# `uname -m` cannot be used for this.
+new_case; make_firmware 1 0 32
+check "fw_platform_size 32 -> 32" "$(lib 'sbPlatformBits')" "32"
+
+# 9c. Unreadable width reads as "unknown" and callers proceed. The kernel has
+# exposed this since 4.14 so it should not happen on UEFI, and refusing on it
+# would break every x86-64 client to guard a case that cannot occur.
+new_case; make_firmware 1 0 -
+check "absent fw_platform_size -> unknown" "$(lib 'sbPlatformBits')" "unknown"
+
+# 9c-ii. ...and does so silently. Without the readability test the wildcard
+# still yields "unknown", so stdout alone cannot tell the two apart -- but bash
+# writes "No such file or directory" to stderr on the way, and on a BIOS-booted
+# client that is an alarming line printed by a task doing the right thing. This
+# is the case that makes the guard load-bearing rather than decorative.
+new_case; make_firmware 1 0 -
+check "absent fw_platform_size is silent on stderr" \
+    "$( ( lib 'sbPlatformBits' ) 2>&1 1>/dev/null )" ""
+
+# 9d. A value that is neither 32 nor 64 is not passed through to a caller that
+# only compares against 32. Returning it raw would be a silent third answer.
+new_case; make_firmware 1 0 64
+echo "banana" > "$SANDBOX/sys/firmware/efi/fw_platform_size"
+check "unparseable fw_platform_size -> unknown" "$(lib 'sbPlatformBits')" "unknown"
 
 # --- certificate fetch ---
 


### PR DESCRIPTION
Closes #140.

The enrolment task had no architecture check. On an ia32 client that produced one of two wrong outcomes.

**Outside Setup Mode** it staged a MOK request, printed a one-time password and *"a blue MOK Manager screen appears on the next boot"*, and reported **Task Complete**. Nothing will ever read that `MokNew` — `MokList` is a shim variable and no Microsoft-signed 32-bit shim exists for the machine to boot. Same false-success class as #136.

**In Setup Mode** it was worse than useless, and this is the part that reversed the recommendation in #134:

| | shim | signed iPXE |
|---|---|---|
| x86_64 | `shimx64.efi` | `x86_64-sb/snponly.efi`, `ipxe.efi` |
| arm64 | `shimaa64.efi` | `arm64-sb/snponly.efi`, `ipxe.efi` |
| **ia32** | **none** | **none** |

The `db` write works — nothing in it is architecture-specific — which is exactly why "degrade to the db path" looked reasonable. But it has no chain to make bootable; FOG serves ia32 clients an unsigned `i386-efi/snponly.efi`. And Setup Mode is the *only* state where the task can run there, because nothing is enforcing. Path 1 finishes by writing the `PK`, which is what leaves Setup Mode. So degrading takes a machine FOG can image today, makes it enforceable, and leaves it with nothing signed to load — irreversibly from the client's side.

## The change

- `sbPlatformBits()` reads `/sys/firmware/efi/fw_platform_size` — firmware width, not CPU width. ia32 UEFI overwhelmingly runs on 64-bit CPUs, so `uname -m` answers a different question.
- `fog.enrollsb` refuses before the certificate fetch and before the already-trusted short-circuit. No `db` contents make enrolment useful here.
- An unreadable value reads `unknown` and callers proceed — refusing on it would break x86-64 clients to guard a case the kernel has made impossible since 4.14.
- ADR-0009 corrected: it said "path 1 would still work there", true of the write and wrong about the outcome.

## Tests

47 cases (was 43), mutation-checked against pinning the output to 64, passing the raw value through, and dropping the readability guard.

That third mutation **initially passed** — a missing file reaches `unknown` through the wildcard either way, so the guard was only observable on stderr. Rather than claim coverage the test didn't have, the redundant `2>/dev/null` came off and a case now asserts the silence, which is the behaviour that matters on a BIOS-booted client. Given this ADR has now recorded three designs that passed their tests and were still wrong, that seemed worth doing properly.

The refusal itself is in the entry point beside the existing `nonefi`/`noefivars` ones, which the harness also cannot reach — it sources the library, not `fog.enrollsb`. Verified by lifting the guard verbatim out of the script and running it against 32 / 64 / absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)