### PR TITLE
Renumber the kernel-hardening ADR to 0010, resolving the duplicate 0009

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,17 @@ and add a new ADR for any similarly hard-to-reverse decision:
   authenticated-write bit is not optional); efivarfs needs prefix and payload in
   a single `write()`; and `PK` is written **last**, because writing it leaves
   Setup Mode and any write after it must be signature-checked.
+- **0010 — Secure Boot kernel hardening.** The lockdown LSM and the platform
+  keyring are built into all three arch configs but lockdown is **not activated**
+  (`CONFIG_LOCK_DOWN_KERNEL_FORCE_NONE=y`) — activating it is downstream-only
+  work gated on the vendor-shim question. `CONFIG_LSM` is set explicitly rather
+  than left to `oldconfig`, because an LSM missing from the ordered list never
+  initialises, and `CONFIG_LOAD_UEFI_KEYS` is what imports the firmware's `db`
+  and `MokList` into the platform keyring. The trap this ADR exists for:
+  `make oldconfig` **silently drops** any symbol whose dependencies are unmet,
+  so a config can look right in git and produce a kernel missing lockdown
+  entirely — which is why `tests/checks/secureboot-config.sh -b` inspects the
+  post-`oldconfig` `.config` rather than the one we wrote.
 
 General conventions to preserve when editing `funcs.sh`/`partition-funcs.sh`:
 

--- a/docs/adr/0010-secure-boot-kernel-hardening.md
+++ b/docs/adr/0010-secure-boot-kernel-hardening.md
@@ -1,4 +1,4 @@
-# 0009 — Secure Boot kernel hardening, and why lockdown is not yet activated
+# 0010 — Secure Boot kernel hardening, and why lockdown is not yet activated
 
 ## Status
 

--- a/tests/checks/secureboot-config.sh
+++ b/tests/checks/secureboot-config.sh
@@ -11,7 +11,7 @@
 # not met. A hand-edited config can therefore look completely correct in git and
 # still produce a kernel with lockdown missing, and nothing anywhere says so.
 # That failure would only surface as a Secure Boot client behaving differently
-# from the one you tested. See docs/adr/0009-secure-boot-kernel-hardening.md
+# from the one you tested. See docs/adr/0010-secure-boot-kernel-hardening.md
 #
 # The -b mode is the one that actually proves anything, because it inspects the
 # config Kconfig produced rather than the one we wrote. Run it after a build.


### PR DESCRIPTION
Two ADRs both claimed 0009, added a day apart during overlapping Secure Boot work:

| File | Added | Commit |
|---|---|---|
| `0009-secure-boot-kernel-hardening.md` | 2026-08-02 | `80eb6a5` |
| `0009-secure-boot-enrolment-paths.md` | 2026-08-03 | `02d2945` |

So every "ADR-0009" cross-reference has been ambiguous since — including ones in shipped code comments and in another repo.

## Which one moves

Chronology says the earlier file keeps the number. Everything else says otherwise, and a one-day tie is not much seniority to spend on it:

- **`enrolment-paths` has nine inbound references** — `secureboot-funcs.sh` ×2, `tests/checks/secureboot.sh`, the ADR index in `CLAUDE.md`, and four in FOGProject/fogproject, one of which is a full URL inside that repo's own ADR-0008.
- **`kernel-hardening` has one**, by full filename, in `tests/checks/secureboot-config.sh`.
- `CLAUDE.md` has listed 0009 as "Secure Boot enrolment" since it was written, so the repo already answers this in practice.

Moving kernel-hardening breaks nothing outside this repo. Moving the other one would strand references in fogproject and in already-published issue bodies.

## Also: registering 0010 in the index

The collision happened because kernel-hardening was never added to the ADR index in `CLAUDE.md` — so the next author read the index, saw 0008 as the highest, and picked a number that was already taken. Adding the entry is the part that stops this recurring, so it's included here rather than left for later.

Docs and one comment line only; no behaviour changes. `secureboot-config.sh` and `secureboot.sh` both still pass.