### PR TITLE
Secure Boot ADRs: settle the UKI question, reject a MokList bypass, add the Microsoft-signed-shim long game

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,13 +168,17 @@ and add a new ADR for any similarly hard-to-reverse decision:
   post-`oldconfig` `.config` rather than the one we wrote.
 - **0011 — UKI feasibility.** Settles the question ADR 0010 left open:
   adopting a Unified Kernel Image is feasible and does not require FOS to run
-  systemd (the addon mechanism is boot-stage-only), but it is gated on moving
-  task selection (`mode=`, `type=`, host identity) out of the network-supplied
-  boot cmdline and into an extended version of the runtime checkin
-  `bin/fog.checkin` already performs — every current `/proc/cmdline` consumer
-  (`funcs.sh:9-13`, `S40network`, `fog.capone`, `fog.sysinfo`) would need to
-  move to that channel instead. The per-deployment `web=` bootstrap mechanism
-  is left as an open follow-up spike, not yet decided.
+  systemd (the addon mechanism is boot-stage-only), and does not touch the
+  custom kernel itself (Realtek drivers, Intel VMD, module-free build). It is
+  gated on redesigning FOS's boot-time config channel, which splits into three
+  subclasses, only the first of which this ADR actually solves: server-known
+  task data (`mode=`, `type=`, image id) can move into an extended version of
+  the runtime checkin `bin/fog.checkin` already performs; the `web=` server
+  address **cannot** — `S40network` needs it before any network round-trip is
+  reachable, so it needs a signed addon or DHCP-derived discovery instead, not
+  a coin-flip choice; and boot-menu flags a human picks at iPXE (`isdebug`,
+  `keymap`, `mdraid`, `chkdsk`, `mc`, `setmacto`) aren't server-known data at
+  all and need their own design pass. See the ADR for the full analysis.
 
 General conventions to preserve when editing `funcs.sh`/`partition-funcs.sh`:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,15 @@ and add a new ADR for any similarly hard-to-reverse decision:
   so a config can look right in git and produce a kernel missing lockdown
   entirely — which is why `tests/checks/secureboot-config.sh -b` inspects the
   post-`oldconfig` `.config` rather than the one we wrote.
+- **0011 — UKI feasibility.** Settles the question ADR 0010 left open:
+  adopting a Unified Kernel Image is feasible and does not require FOS to run
+  systemd (the addon mechanism is boot-stage-only), but it is gated on moving
+  task selection (`mode=`, `type=`, host identity) out of the network-supplied
+  boot cmdline and into an extended version of the runtime checkin
+  `bin/fog.checkin` already performs — every current `/proc/cmdline` consumer
+  (`funcs.sh:9-13`, `S40network`, `fog.capone`, `fog.sysinfo`) would need to
+  move to that channel instead. The per-deployment `web=` bootstrap mechanism
+  is left as an open follow-up spike, not yet decided.
 
 General conventions to preserve when editing `funcs.sh`/`partition-funcs.sh`:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,17 @@ and add a new ADR for any similarly hard-to-reverse decision:
   a coin-flip choice; and boot-menu flags a human picks at iPXE (`isdebug`,
   `keymap`, `mdraid`, `chkdsk`, `mc`, `setmacto`) aren't server-known data at
   all and need their own design pass. See the ADR for the full analysis.
+- **0012 — Microsoft-signed FOG shim (proposed, unstarted).** The only way to
+  remove Secure Boot enrolment entirely rather than automate it further —
+  gated on ADR-0011's redesign actually shipping, and on the still-inactive
+  ADR-0010 lockdown patch. `ipxe/shim` cannot be repurposed for this (it
+  trusts exactly one thing, derives its second stage from its own filename,
+  and has no downstream hook by design); it requires FOG's own shim fork with
+  FOG's certificate as the vendor cert, an EV cert from the Microsoft Hardware
+  Dev Center, HSM/smartcard key custody, and a `rhboot/shim-review`
+  submission — which carries **permanent** CVE/hash-revocation duty
+  afterward, not a one-time cost. Tracked upstream as
+  FOGProject/fogproject#995.
 
 General conventions to preserve when editing `funcs.sh`/`partition-funcs.sh`:
 

--- a/docs/adr/0009-secure-boot-enrolment-paths.md
+++ b/docs/adr/0009-secure-boot-enrolment-paths.md
@@ -39,6 +39,43 @@ bug; report it upstream rather than depend on it.
 stages a request. It does not enrol anything, no message in `fog.enrollsb` may
 claim it did, and the task reports "pending", not "enrolled".
 
+#### Rejected: a Microsoft-signed generic UEFI Shell writing `MokList` directly
+
+Worth naming explicitly, because it is the specific "found a way around Wall 1"
+case the paragraph above warns about, and it is tempting enough to get
+rediscovered. `MokList` carries only `NV|BS` attributes — it is **not** an
+authenticated variable the way `PK`/`KEK`/`db` are. The MokManager password is
+a MokManager *application* convention, not a firmware access-control check on
+the variable itself. Any EFI code running before `ExitBootServices` can call
+`SetVariable()` on it directly.
+
+The standard edk2 UEFI Shell — which Microsoft has signed and some vendors
+ship — includes `dmpstore`, a generic NVRAM save/restore command with no
+concept that `MokList` is special. Point it at a hand-crafted file with the
+right name/GUID/attributes/bytes and it writes an arbitrary cert list into
+`MokList` with no password, no MokManager screen, no physical presence. This
+is not a novel idea: it is the same technique class behind real Secure Boot
+bypasses in the wild (the BlackLotus bootkit is the most prominent), which is
+exactly why Microsoft has been revoking specific signed shell/bootloader
+hashes via `dbx` over time.
+
+**Rejected, not "not yet built."** Two independent reasons, not one:
+
+- It is a documented Secure Boot bypass class, not a shortcut — shipping it as
+  a FOG feature means FOG's own automation does what a bootkit does, and
+  undermines the exact guarantee this ADR and ADR-0010 exist to preserve for
+  every FOG deployment.
+- It is not durable even on its own terms. Microsoft actively revokes
+  known-vulnerable signed shells via `dbx`, so automation built on this can
+  stop working — or get flagged by security tooling watching for this exact
+  behavior — at a time FOG does not control.
+
+The real, legitimate versions of "close the enrolment gap further" are Path 1
+below (Setup Mode, or a signed update once FOG already owns the platform's
+`PK`/`KEK`), Path 2 (out-of-band BMC), or — the only way to remove the
+enrolment step entirely — FOGProject/fogproject#995, tracked in
+[ADR-0012](0012-fog-vendor-shim-signed-by-microsoft.md).
+
 ### Wall 2 — FOS itself is not loadable until the key is already trusted
 
 **This is the correction.** An earlier revision of this ADR assumed FOS could
@@ -126,6 +163,32 @@ silently, so each has a dedicated assertion in the harness:
 
 All three blobs are downloaded before any is written: a web server hiccup should
 cost a retry, not leave a platform mid-enrolment.
+
+#### An alternate front-end: user-supplied WinPE
+
+A site that would rather not PXE-boot FOS for the enrolment step — or prefers
+a Windows-native workflow — has another way to drive the exact same mechanism.
+WinPE boots via Windows Boot Manager, verified directly against Microsoft's
+certificates already in `db`. No shim, no `MokList`, nothing to enrol just to
+get WinPE running. Windows exposes an officially supported equivalent of
+`sbWriteEfiAuthVar()`/`sbEnrollDb()` for this exact purpose: the
+`Set-SecureBootUEFI` PowerShell cmdlet, which writes the same signed
+authenticated-variable updates.
+
+**FOG's deliverable here is a script, not a WinPE image.** Microsoft's Windows
+ADK / WinPE licensing does not permit a third party to freely redistribute
+built WinPE images carrying Microsoft's binaries — the pattern other imaging
+tools (MDT, SCCM boot media, and others) use instead is to ship an add-in
+payload the customer injects into a WinPE they build themselves from their own
+licensed ADK. FOG's equivalent would be a script that fetches the same
+`PK.auth`/`KEK.auth`/`db.auth` blobs `sbFetchAuthVar()` already serves and
+pushes them via `Set-SecureBootUEFI`, for the customer to add to their own
+build.
+
+This is a different front-end for Path 1, not a way around Wall 1 or Wall 2 —
+it still cannot touch `MokList`, and the machine still has to already be in
+(or willing to enter) Setup Mode. It has not been built; recorded here as a
+validated direction should a Windows-native front-end become worth building.
 
 ### 2. Out-of-band (Redfish / vendor BMC) — the only zero-touch tier
 

--- a/docs/adr/0010-secure-boot-kernel-hardening.md
+++ b/docs/adr/0010-secure-boot-kernel-hardening.md
@@ -128,6 +128,11 @@ That question is worth answering **before** anyone writes the lockdown patch.
 If FOG cannot move to a UKI, an application for its own shim probably is not
 winnable, and the patch buys nothing on its own.
 
+**Settled in ADR 0011**: adopting a UKI is feasible, gated on moving task
+selection out of the boot cmdline and into an extended version of the runtime
+checkin `bin/fog.checkin` already performs. See that ADR for the analysis and
+what it leaves open before implementation can start.
+
 ## Consequences
 
 - The configs are inert for now: lockdown is compiled in but never activated,

--- a/docs/adr/0011-unified-kernel-image-feasibility.md
+++ b/docs/adr/0011-unified-kernel-image-feasibility.md
@@ -1,0 +1,137 @@
+# 0011 — Adopting a UKI is feasible, gated on moving task selection off the boot cmdline
+
+## Status
+
+Proposed. This settles the question ADR 0010 raised and left open
+("Settle the initrd question before going further") and answers
+FOGProject/fogproject#995's gate ("nothing else here is worth starting until
+this is answered"). It is a decision, not an implementation — no code has
+changed. The redesign it recommends, and the lockdown-activation patch ADR
+0010 is gated behind it, are both separate future work.
+
+## Context
+
+FOS boots as `bzImage` plus a kernel command line built dynamically by iPXE,
+per host, per task — `web=` (FOG server URL), `mode=`, `type=`, host identity —
+plus an unsigned ext2 `init.xz`. This is not incidental: it is FOS's only
+channel for task selection. `funcs.sh:9-13` re-parses `/proc/cmdline` into
+exported env vars every time a subshell needs them, and `etc/init.d/S40network`,
+`bin/fog.checkin`, `bin/fog.capone`, `bin/fog.sysinfo` each independently
+re-parse it again. Nothing downstream knows what to do without it.
+
+A UKI's `.cmdline` PE section is fixed at build/sign time, covered by the same
+signature as the kernel and initrd. Stapling FOS's current cmdline into a UKI
+verbatim is a contradiction — it would have to stay dynamic and unsigned to do
+its job, which defeats the point of signing it at all. That contradiction is
+exactly why this question had to be settled before writing the
+lockdown-on-Secure-Boot patch: a signed kernel that still boots off an
+attacker-shaped cmdline and initrd buys nothing.
+
+## Findings
+
+**1. UKI addons do not require FOS to run systemd.** Per the UAPI Group's UKI
+specification and `systemd-stub`'s own docs, the stub is boot-stage-only code
+that runs "before transitioning into the Linux kernel environment"; addon
+files are parsed and verified by the stub itself, before the kernel — let
+alone any init system — starts. `systemd-stub` ≠ `systemd-boot` ≠ systemd as
+PID 1. FOS could adopt a UKI, and even the addon mechanism, while keeping
+BusyBox init untouched at runtime. The only new dependency is the stub binary
+glued onto the kernel and `ukify`/`objcopy` as host-side build tooling — not a
+runtime one. This was the one plausible hard blocker and it isn't one.
+
+**2. `rhboot/shim-review` does not literally require a UKI.** Its actual
+docs ask submitters to "address how secure boot is enforced in \[their\] boot
+stack and how \[their\] boot stack prevents execution of unauthenticated
+code" — UKI is one accepted answer, not the requirement itself. ADR 0010
+already reached the same conclusion independently. What a reviewer will
+actually push on is FOS's specific current shape: a signed kernel that hands
+control to an initrd and cmdline supplied by whatever answered DHCP, which is
+most of the way back to the bypass Secure Boot exists to prevent — UKI is the
+straightforward fix for *that* shape, even though nothing mandates it by name.
+
+**3. Real precedent exists for "generic signed image, config fetched after
+boot."** Talos Linux boots a single signed UKI (shim → signed systemd-boot →
+signed UKI) into what it calls "maintenance mode," with no per-node config
+baked in, then an operator pushes node-specific config over an authenticated
+network call after boot. This is the closest real-world analogue to the shape
+FOS would need, and it is not a pattern FOS would be inventing from scratch.
+Kairos and Flatcar take a related but distinct approach — dynamic config as
+*data* consumed by already-trusted userspace, rather than dynamic *cmdline*
+driving the kernel's own security posture — which is a materially different
+(weaker, for this purpose) trust boundary and not the one recommended below.
+
+## Decision
+
+**Go**, via a generic-signed-UKI-plus-runtime-checkin redesign, not a
+per-boot signed addon:
+
+- **Base UKI**: FOS's kernel + initrd + a fixed, minimal cmdline — no `mode=`,
+  `type=`, host identity, or `web=` — signed once per FOS release, identical
+  for every deployment and every boot. This is the artifact `build.sh` would
+  produce and sign, replacing today's separate `bzImage`/`init.xz` signing.
+- **Task selection moves into the existing checkin round-trip.**
+  `bin/fog.checkin:50-72` already POSTs `mac`/`type`/`sysuuid` to
+  `${web}service/Pre_Stage1.php` and blocks until the server answers `##@GO` —
+  the shape of an authenticated runtime handshake already exists. Extend that
+  response from a bare `##@GO` into a real payload carrying `mode`, `type`,
+  image id, and whatever else is on the cmdline today, and change every
+  current `/proc/cmdline` consumer (`funcs.sh:9-13`, `S40network`,
+  `fog.capone`, `fog.sysinfo`) to source from it instead. This is a redesign of
+  FOS's config channel, not a bolt-on: it touches the same four files that
+  read `/proc/cmdline` today, nothing more.
+- **`web=` is the one genuinely per-deployment (not per-boot) variable left**,
+  and this ADR does not pick its mechanism — two candidates, either workable:
+  a signed per-deployment addon UKI carrying just `web=`, signed with that
+  FOG install's own key (reusing the signing infrastructure already built for
+  FOGProject/fogproject#961); or deriving it from the DHCP/PXE next-server
+  field the client already receives during network boot, without needing the
+  kernel cmdline's help at all. Left as a follow-up spike — see below.
+
+## What this does not resolve
+
+- **The `web=` bootstrap mechanism** — two candidates named above, neither
+  chosen. Needs a short, separate spike before implementation starts.
+- **`fog.checkin`'s TLS is unverified today** (`curl -k`). That is not a new
+  problem this ADR introduces, but the channel becomes more load-bearing once
+  it also carries task selection, not just image content — worth tightening
+  as companion hardening, not a blocker to adopting UKI itself.
+- **This is a two-repo change.** FOGProject/fogproject's iPXE-generation logic
+  and `Pre_Stage1.php` (or its successor) need corresponding updates to stop
+  building a per-host cmdline and start answering the extended checkin instead.
+  That work is out of scope here but has to land in lockstep with anything
+  done in this repo.
+- **Nothing has been built or booted.** Per the precedent ADR 0003 and ADR
+  0010 both set, this conclusion should not be treated as de-risked until a
+  real x64 build actually produces and boots a signed UKI end-to-end, and a
+  machine images successfully off of it.
+- **The lockdown-on-Secure-Boot patch itself** (ADR 0010) remains separate,
+  future work. This ADR unblocks it; it does not implement it.
+
+## Consequences
+
+- Unblocks ADR 0010's lockdown-activation patch and the shim-review
+  application tracked in FOGProject/fogproject#995 — but only once the
+  runtime-checkin redesign above is actually built, not on the strength of
+  this decision alone.
+- Shrinks what iPXE has to construct at boot: today, a full host-specific
+  cmdline per boot; after, chainloading one fixed signed UKI for every host.
+  That is a net simplification on the fogproject side, not purely a security
+  tax paid for shim-review's benefit.
+- Adds a new build-time dependency: assembling the UKI (kernel + initrd + PE
+  sections) requires stub/tooling (`ukify`, `objcopy`) beyond the kernel's own
+  `CONFIG_EFI_STUB`, which `build.sh` does not currently carry.
+
+## References
+
+- FOGProject/fogproject#995 (successor to the now-closed #962), the tracking
+  issue this ADR answers.
+- ADR 0010 (`secure-boot-kernel-hardening`), "Settle the initrd question
+  before going further."
+- UAPI Group Unified Kernel Image specification —
+  <https://uapi-group.org/specifications/specs/unified_kernel_image/>
+- `systemd-stub(7)` — <https://www.freedesktop.org/software/systemd/man/latest/systemd-stub.html>
+- `rhboot/shim-review` — <https://github.com/rhboot/shim-review>
+- Talos Linux, Secure Boot on bare metal —
+  <https://docs.siderolabs.com/talos/v1.9/platform-specific-installations/bare-metal-platforms/secureboot>
+- `bin/fog.checkin:50-72`, `usr/share/fog/lib/funcs.sh:9-13` — the existing
+  runtime-checkin and cmdline-parsing code this decision builds on.

--- a/docs/adr/0011-unified-kernel-image-feasibility.md
+++ b/docs/adr/0011-unified-kernel-image-feasibility.md
@@ -1,4 +1,4 @@
-# 0011 — Adopting a UKI is feasible, gated on moving task selection off the boot cmdline
+# 0011 — Adopting a UKI is feasible, gated on redesigning FOS's boot-time config channel
 
 ## Status
 
@@ -59,6 +59,21 @@ Kairos and Flatcar take a related but distinct approach — dynamic config as
 *data* consumed by already-trusted userspace, rather than dynamic *cmdline*
 driving the kernel's own security posture — which is a materially different
 (weaker, for this purpose) trust boundary and not the one recommended below.
+FOS already carries a smaller version of the same idea internally: USB boot
+(where iPXE cannot inject a cmdline at all) already fetches config over the
+network keyed by MAC/system UUID and sources it at runtime —
+`bin/fog:4-11` POSTs to `hostinfo.php`, writes the response to
+`/tmp/hinfo.txt`, and sources it before dispatch. That path still depends on
+`$web` already being known (see below), but it is evidence the general shape
+already works in this codebase, not just at Talos's scale.
+
+**4. Adopting a UKI does not touch the custom kernel.** A UKI is an assembly
+step on top of the *same* `bzImage` `build.sh` already produces — it changes
+nothing about kernel configuration, the built-in Realtek drivers, the Intel
+VMD patch, or the no-external-modules build. Those are Kconfig/source-tree
+concerns; the UKI only staples the finished kernel binary, the initrd, and a
+cmdline into one signed PE file. The two reasons FOS carries a custom kernel
+at all (ADR 0010) are unaffected by anything in this ADR.
 
 ## Decision
 
@@ -69,28 +84,52 @@ per-boot signed addon:
   `type=`, host identity, or `web=` — signed once per FOS release, identical
   for every deployment and every boot. This is the artifact `build.sh` would
   produce and sign, replacing today's separate `bzImage`/`init.xz` signing.
-- **Task selection moves into the existing checkin round-trip.**
+- **Server-known task data moves into the existing checkin round-trip.**
   `bin/fog.checkin:50-72` already POSTs `mac`/`type`/`sysuuid` to
   `${web}service/Pre_Stage1.php` and blocks until the server answers `##@GO` —
   the shape of an authenticated runtime handshake already exists. Extend that
   response from a bare `##@GO` into a real payload carrying `mode`, `type`,
-  image id, and whatever else is on the cmdline today, and change every
-  current `/proc/cmdline` consumer (`funcs.sh:9-13`, `S40network`,
-  `fog.capone`, `fog.sysinfo`) to source from it instead. This is a redesign of
-  FOS's config channel, not a bolt-on: it touches the same four files that
-  read `/proc/cmdline` today, nothing more.
-- **`web=` is the one genuinely per-deployment (not per-boot) variable left**,
-  and this ADR does not pick its mechanism — two candidates, either workable:
-  a signed per-deployment addon UKI carrying just `web=`, signed with that
-  FOG install's own key (reusing the signing infrastructure already built for
-  FOGProject/fogproject#961); or deriving it from the DHCP/PXE next-server
-  field the client already receives during network boot, without needing the
-  kernel cmdline's help at all. Left as a follow-up spike — see below.
+  image id, and other data the FOG server already decides. Everything
+  downstream just reads the environment `funcs.sh:9-13` currently populates
+  from `/proc/cmdline` — not the cmdline directly — so replacing that one
+  export point is enough to cover `$mode`/`$type`/image-id-class variables
+  without touching the dozens of files (`$web` alone appears in 18) that
+  merely consume the resulting env vars. This covers the data the *server*
+  decides. It does **not** cover the two subclasses below.
+- **`web=` cannot be solved by the checkin redesign at all, and is not a
+  coin flip between two equally-fine options.** `S40network:48` calls
+  `curl "${web}"/index.php` immediately after DHCP just to confirm the network
+  came up — before `fog.checkin` or any runtime round-trip is reachable. A
+  runtime checkin cannot supply the address of the server it needs to reach to
+  perform that checkin. This has to be solved by something present *before*
+  any network call: a signed per-deployment addon UKI carrying just `web=`
+  (signed with that FOG install's own key, reusing #961's infrastructure), or
+  deriving it from the DHCP/PXE next-server field already received during
+  network boot. Left as a follow-up spike, but not optional the way the
+  wording above might imply — some such mechanism is required.
+- **Boot-menu flags chosen by a human are a separate, unaddressed subclass.**
+  `$isdebug`, `$keymap`, `$mdraid`, `$chkdsk`, `$mc`, `$setmacto` (used in
+  `S40network`, `fog.checkin`, `S99fog`, `partition-funcs.sh`, and elsewhere)
+  are picked at iPXE's interactive boot menu, before any FOG-server round-trip
+  and independent of whatever task the server has scheduled. "Move task
+  selection into checkin" does not cover these, because the server has no way
+  to know what a human just chose in the menu unless iPXE tells it first —
+  which means a second, separate network call (from iPXE, at menu-selection
+  time, keyed by MAC) reporting the choice so the server can hand it back
+  during the later checkin. That call has the same `web=`-bootstrap
+  dependency as everything else here. This subclass needs its own design pass
+  before implementation starts; this ADR does not resolve it.
 
 ## What this does not resolve
 
 - **The `web=` bootstrap mechanism** — two candidates named above, neither
-  chosen. Needs a short, separate spike before implementation starts.
+  chosen, and not optional (some such mechanism is required, since nothing
+  else here can bootstrap it). Needs a short, separate spike before
+  implementation starts.
+- **The boot-menu-flags subclass** (`isdebug`, `keymap`, `mdraid`, `chkdsk`,
+  `mc`, `setmacto`, …) — needs its own design pass; "move task selection to
+  checkin" does not cover data a human chooses at the iPXE menu rather than
+  data the FOG server already knows.
 - **`fog.checkin`'s TLS is unverified today** (`curl -k`). That is not a new
   problem this ADR introduces, but the channel becomes more load-bearing once
   it also carries task selection, not just image content — worth tightening

--- a/docs/adr/0012-fog-vendor-shim-signed-by-microsoft.md
+++ b/docs/adr/0012-fog-vendor-shim-signed-by-microsoft.md
@@ -1,0 +1,135 @@
+# 0012 — A Microsoft-signed FOG shim: the long game, recorded before it's lost
+
+## Status
+
+Proposed. Research recorded, no work started. This is the only route that
+removes Secure Boot enrolment entirely rather than automating it further; it
+is a multi-month, ongoing-cost undertaking and should be weighed as one before
+anyone starts.
+
+## Context
+
+Every path in [ADR-0009](0009-secure-boot-enrolment-paths.md) — MOK staging,
+Setup Mode `db` writes, out-of-band BMC — asks for something at the machine:
+a technician's confirmation, a firmware visit, or a BMC that happens to expose
+the right API. All of them exist because FOG's certificate has to become
+trusted *somewhere*, and only Microsoft's signature is trusted everywhere by
+default. A shim of FOG's own, signed by Microsoft with FOG's certificate baked
+in as the vendor certificate, is the only way to make a FOG-signed kernel boot
+out of the box on stock hardware with no enrolment step at all.
+
+This is tracked upstream as FOGProject/fogproject#995 (successor to the
+now-closed #962, which did the initial investigation). Nothing here has been
+started; this ADR exists so the research already done in those two issues
+lives in this repo too, rather than only in GitHub.
+
+## The gate, already settled
+
+#995 states its own precondition directly: "nothing else here is worth
+starting until \[the UKI question\] is answered." FOS boots as `bzImage` plus
+a per-host cmdline built dynamically by iPXE, plus an unsigned ext2 initrd — a
+signed kernel handing control to an initrd and cmdline supplied by whatever
+answered DHCP is close to the exact thing shim exists to prevent, and a
+reviewer will push hard on that shape.
+
+[ADR-0011](0011-unified-kernel-image-feasibility.md) answers this: **Go**, via
+a generic signed UKI (fixed minimal cmdline, no per-host data) plus moving task
+selection into the existing `fog.checkin` round-trip. That decision is
+proposed, not built or booted end-to-end — this ADR does not re-litigate it,
+only builds on top of it. Nothing below is worth starting until ADR-0011's
+redesign actually ships.
+
+## Why `ipxe/shim` cannot be reused
+
+Worth stating plainly so it isn't attempted and rediscovered as a dead end.
+`ipxe/shim` trusts exactly one thing — the iPXE Secure Boot CA — and derives
+its second stage from its own filename (the tarball ships `ipxe-shim.efi` and
+`snponly-shim.efi` as symlinks to one `shimx64.efi` for exactly this reason).
+There is no downstream hook, by design: a shim that loaded any binary calling
+itself iPXE would be worthless as a security boundary. Nothing FOG builds can
+satisfy it. A Microsoft-signed FOG shim means building and maintaining FOG's
+own fork of `rhboot/shim`, with FOG's own vendor certificate compiled in —
+not repurposing iPXE's.
+
+## Precedent not to follow
+
+[abotzung/foguefi](https://github.com/abotzung/foguefi) looks like it solves
+this but sidesteps it instead: it downloads Canonical's pre-signed
+`shimx64.efi` + `grubx64.efi` + Ubuntu's signed kernel, and carries FOG's
+imaging logic in an unsigned initrd. There is no FOS kernel anywhere in that
+chain, iPXE is dropped entirely, and the project is archived with unfinished
+docs. It demonstrates that *a* signed chain can be made to boot something,
+not that FOG's own kernel can be trusted anywhere without either MOK/Setup
+Mode enrolment or exactly the shim-signing work this ADR describes.
+
+## Remaining checklist, from #995
+
+- [x] Kernel config groundwork — FOGProject/fos#131 (lockdown LSM built in,
+      left inactive; see ADR-0010)
+- [ ] The lockdown-on-Secure-Boot activation patch. Both halves are
+      downstream-only in kernel 6.18: `security_lock_kernel_down()` is not in
+      mainline, nor is `efi_enabled(EFI_SECURE_BOOT)`. ADR-0010 has the hook
+      point and a smaller single-file alternative.
+- [ ] The UKI/runtime-checkin redesign itself (ADR-0011) — decided, not built.
+- [ ] SBAT metadata, signing infrastructure, key custody — not started.
+- [ ] `rhboot/shim-review` submission — not started.
+
+## The real cost, stated plainly
+
+Worth weighing honestly before any of the checklist above is started, because
+the last item does not go away:
+
+- An EV certificate from the Microsoft Hardware Dev Center.
+- HSM or smartcard key custody for that certificate.
+- A named security contact with a PGP key.
+- A build from the shim 16.1 tarball using a frozen-toolchain Dockerfile.
+- A vendor SBAT entry.
+- A signed kernel that actually enforces lockdown (the ADR-0010 patch above).
+- A volunteer-run review, two to three months minimum.
+- **Permanent CVE and hash-revocation duty afterward.** This is the part to
+  weigh most honestly: it is not a project that finishes.
+
+## A clarification worth stating explicitly
+
+#962/#995 record that fleet-scale `db` enrolment via firmware tooling is
+"mostly a dead end" as a *general* answer on stock OEM hardware: `db`/`dbx`
+updates must be signed by the currently-trusted `PK`/`KEK`, and on unmodified
+OEM firmware that key belongs to Microsoft or the OEM, not FOG. Dell genuinely
+exposes programmable custom-mode `PK`/`KEK`/`db` import via Dell Command |
+Configure and iDRAC; Lenovo's ThinkBIOS Config can clear `PK` into Setup Mode
+but unattended cert push is unconfirmed; HP consumer lines have no enrolment
+mode at all, and HP commercial is unconfirmed.
+
+This is a **different scenario** from a machine that has already been through
+ADR-0009 Path 1, where FOG's own `PK`/`KEK` is now the one installed — on such
+a machine FOG legitimately holds the signing key for future `db` updates, and
+those updates are a signature check, not a firmware-tooling problem. The two
+should not be conflated: "fleet-scale enrolment on stock OEM hardware is a
+dead end" and "a FOG-owned platform can take further signed updates with no
+Setup Mode revisit" are both true, about different machines.
+
+## Consequences
+
+- No code changes from this ADR alone. It records research that otherwise
+  exists only in FOGProject/fogproject#995 and #962.
+- Nothing here is actionable until ADR-0011's UKI/runtime-checkin redesign is
+  actually built and boots on real hardware, and until ADR-0010's
+  lockdown-activation patch exists.
+- Starting the shim-review submission itself is an organizational commitment
+  (key custody, a standing security contact, ongoing revocation duty), not
+  purely an engineering task, and should be decided as such rather than as a
+  natural next step once the technical prerequisites land.
+
+## References
+
+- FOGProject/fogproject#995 — "Secure Boot: a FOG vendor shim signed by
+  Microsoft — settle the UKI question first"
+- FOGProject/fogproject#962 (closed) — the parent tracking issue; source of
+  the `ipxe/shim` and `foguefi` findings and the OEM-tooling survey
+- [ADR-0009](0009-secure-boot-enrolment-paths.md) — the enrolment paths this
+  would eventually make unnecessary for new installs
+- [ADR-0010](0010-secure-boot-kernel-hardening.md) — the lockdown-activation
+  patch this depends on
+- [ADR-0011](0011-unified-kernel-image-feasibility.md) — the UKI gate this
+  depends on, already decided
+- `rhboot/shim-review` — <https://github.com/rhboot/shim-review>


### PR DESCRIPTION
## Summary
- ADR-0011: settles FOGProject/fogproject#995's UKI gate -- adopting a Unified Kernel Image is feasible via a generic signed UKI plus moving task selection into the existing runtime checkin; the `web=` bootstrap and boot-menu-flag subclasses are called out as still unresolved.
- ADR-0009: records a rejected bypass (a Microsoft-signed generic UEFI Shell's `dmpstore` can write `MokList` directly, since it carries no authenticated-write attribute -- the same technique class behind real Secure Boot bypasses like BlackLotus) and a legitimate alternate front-end (user-supplied WinPE for the existing Setup Mode `db`/`KEK`/`PK` path via `Set-SecureBootUEFI`, shipped as a script rather than a redistributed WinPE image for licensing reasons).
- ADR-0012 (new): brings the Microsoft-signed-FOG-shim research from FOGProject/fogproject#995/#962 into this repo -- why `ipxe/shim` can't be repurposed, the `foguefi` precedent, the real cost (EV cert, HSM key custody, shim-review, permanent CVE/revocation duty), and how it relates to ADR-0010/0011.
- CLAUDE.md: registers ADR-0011 and ADR-0012 in the ADR index so future contributors don't miss them (per the lesson from the ADR-0009/0010 renumbering).

## Test plan
- [ ] Documentation only, no code changes -- no test suite applies
- [ ] Read all three ADRs end to end for internal consistency and cross-reference accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)