### PR TITLE
Verify release assets after upload, and retry the ones that didn't land

### DIFF
--- a/.github/workflows/create_experimental_release.yml
+++ b/.github/workflows/create_experimental_release.yml
@@ -384,6 +384,46 @@ jobs:
           files: |
             distribution-files/*
 
+      # Same guard as create_release.yml and make_usb.yml -- see the comment in
+      # the former for the failure this exists for. It matters here despite
+      # these being prereleases: an experimental build is usually handed to one
+      # person to test a specific fix, and "the kernel you sent me doesn't work"
+      # is the most expensive possible way to discover a truncated upload.
+      #
+      # The expected set is whatever the selected arches actually produced,
+      # which is the same glob the upload uses, so partial-arch runs verify
+      # exactly what they published and nothing more.
+      - name: Verify uploaded assets, re-uploading any that are missing or short
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          for attempt in 1 2 3; do
+            incomplete=()
+            for f in distribution-files/*; do
+              name=$(basename "$f")
+              want=$(stat -c%s "$f")
+              got=$(gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" \
+                      --json assets -q ".assets[]|select(.name==\"$name\")|.size" 2>/dev/null)
+              if [[ "$got" != "$want" ]]; then
+                echo "::warning::$name is ${got:-absent} on release $TAG_NAME, expected $want bytes"
+                incomplete+=("$f")
+              fi
+            done
+            if [[ ${#incomplete[@]} -eq 0 ]]; then
+              echo "All release assets present on $TAG_NAME at their expected sizes."
+              exit 0
+            fi
+            if [[ $attempt -lt 3 ]]; then
+              echo "Re-uploading ${#incomplete[@]} asset(s) (attempt $attempt of 3)..."
+              gh release upload "$TAG_NAME" "${incomplete[@]}" \
+                --repo "$GITHUB_REPOSITORY" --clobber || true
+              sleep $((attempt * 10))
+            fi
+          done
+          echo "::error::Release assets still missing or truncated on $TAG_NAME after 3 attempts -- $TAG_NAME is incomplete."
+          exit 1
+
   add_usb_image:
     needs: release
 

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -456,6 +456,50 @@ jobs:
             distribution-files/init_32.xz
             distribution-files/init_32.xz.sha256
 
+      # Same guard as the one in make_usb.yml, and for the same reason: an
+      # individual asset upload can die mid-transfer while the step as a whole
+      # still reports success, publishing a release that looks complete and is
+      # not. That is worse here than for the USB image -- these twelve files are
+      # what every branch install pulls, and a short bzImage or init.xz is a
+      # broken deploy for anyone who fetches it before someone notices.
+      #
+      # The expected set is taken from what the build actually produced rather
+      # than from a second copy of the list above, so the two cannot drift. If
+      # dist ever gains a file that is deliberately not published, this fails
+      # the release until the lists are reconciled, which is the right way round
+      # for a release path (ADR-0003: fail loud rather than ship something
+      # half-written).
+      - name: Verify uploaded assets, re-uploading any that are missing or short
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          for attempt in 1 2 3; do
+            incomplete=()
+            for f in distribution-files/*; do
+              name=$(basename "$f")
+              want=$(stat -c%s "$f")
+              got=$(gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" \
+                      --json assets -q ".assets[]|select(.name==\"$name\")|.size" 2>/dev/null)
+              if [[ "$got" != "$want" ]]; then
+                echo "::warning::$name is ${got:-absent} on release $TAG_NAME, expected $want bytes"
+                incomplete+=("$f")
+              fi
+            done
+            if [[ ${#incomplete[@]} -eq 0 ]]; then
+              echo "All release assets present on $TAG_NAME at their expected sizes."
+              exit 0
+            fi
+            if [[ $attempt -lt 3 ]]; then
+              echo "Re-uploading ${#incomplete[@]} asset(s) (attempt $attempt of 3)..."
+              gh release upload "$TAG_NAME" "${incomplete[@]}" \
+                --repo "$GITHUB_REPOSITORY" --clobber || true
+              sleep $((attempt * 10))
+            fi
+          done
+          echo "::error::Release assets still missing or truncated on $TAG_NAME after 3 attempts -- $TAG_NAME is incomplete."
+          exit 1
+
   add_usb_image:
     needs: release
 

--- a/.github/workflows/make_usb.yml
+++ b/.github/workflows/make_usb.yml
@@ -83,3 +83,51 @@ jobs:
           files: |
             /tmp/fos-usb.img
             /tmp/fos-usb.img.sha256
+
+      # Verify rather than trust, because a partial upload here fails silently.
+      #
+      # On 2026-08-06 this step uploaded fos-usb.img.sha256 fine and then died
+      # with `other side closed` partway through fos-usb.img itself. The release
+      # was left advertising a checksum for a file that was not present -- and
+      # nothing downstream noticed, because the release page renders happily
+      # with a missing asset and every other job in the run was green. The only
+      # user-visible symptom is `sha256sum -c` failing on a pair someone
+      # downloaded, long after the fact.
+      #
+      # A truncated transfer is a transport failure, which is precisely the kind
+      # that succeeds on a second attempt, so re-upload rather than just report.
+      # Sizes are compared instead of checksums deliberately: the failure being
+      # guarded against is a short or absent object, GitHub stores what it
+      # received, and re-hashing a 128 MiB asset over the network on every
+      # release buys nothing against that.
+      - name: Verify uploaded assets, re-uploading any that are missing or short
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          files=(/tmp/fos-usb.img /tmp/fos-usb.img.sha256)
+          for attempt in 1 2 3; do
+            incomplete=()
+            for f in "${files[@]}"; do
+              name=$(basename "$f")
+              want=$(stat -c%s "$f")
+              got=$(gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" \
+                      --json assets -q ".assets[]|select(.name==\"$name\")|.size" 2>/dev/null)
+              if [[ "$got" != "$want" ]]; then
+                echo "::warning::$name is ${got:-absent} on release $TAG_NAME, expected $want bytes"
+                incomplete+=("$f")
+              fi
+            done
+            if [[ ${#incomplete[@]} -eq 0 ]]; then
+              echo "All USB assets present on $TAG_NAME at their expected sizes."
+              exit 0
+            fi
+            if [[ $attempt -lt 3 ]]; then
+              echo "Re-uploading ${#incomplete[@]} asset(s) (attempt $attempt of 3)..."
+              gh release upload "$TAG_NAME" "${incomplete[@]}" \
+                --repo "$GITHUB_REPOSITORY" --clobber || true
+              sleep $((attempt * 10))
+            fi
+          done
+          echo "::error::USB assets still missing or truncated on $TAG_NAME after 3 attempts -- the release is incomplete."
+          exit 1


### PR DESCRIPTION
## What broke

The `20260806-111046` release published with a `fos-usb.img.sha256` and no `fos-usb.img`. The upload step reported success; the asset upload inside it died with `other side closed` partway through the 128 MiB image, after its checksum file had already gone up.

Nothing downstream noticed. The release page renders fine with a missing asset, every other job in the run was green, and the only user-visible symptom is `sha256sum -c` failing for someone who downloaded the pair — long after the fact, with no obvious cause.

`softprops/action-gh-release` does not fail the step when one file in `files:` fails to upload, so "the step succeeded" is not evidence the assets are there.

## The guard

After each upload, compare every asset's size on the release against the file we meant to publish. Re-upload anything missing or short (3 attempts, backing off 10s/20s), and fail the job loudly if it still hasn't converged.

A truncated transfer is a transport failure — the kind that usually succeeds on a second attempt — so repairing beats reporting. Manually re-running the failed job is what fixed the release on the day; this does that automatically and, unlike the manual fix, cannot leave a `.sha256` from one attempt beside an `.img` from another.

## Applied to all three upload paths

A guard on two of three is a trap for whoever later assumes it covers them:

| Workflow | Why |
|---|---|
| `make_usb.yml` | the path that actually broke |
| `create_release.yml` | worse blast radius — these twelve files are what every branch install pulls; a short `bzImage` or `init.xz` is a broken deploy |
| `create_experimental_release.yml` | an experimental build usually goes to one person testing one fix; "the kernel you sent me doesn't work" is the most expensive way to discover a short upload |

## Decisions worth stating

**Sizes, not checksums.** The failure guarded against is a short or absent object; GitHub stores what it received. Re-hashing every asset over the network on each release costs minutes and buys nothing against that specific failure.

**Expected set comes from the build output, not a copy of the upload list.** `create_release.yml` enumerates twelve paths in `files:`; the guard globs `distribution-files/*` instead, so the two cannot drift. If dist ever gains a file that is deliberately not published, this fails until the lists are reconciled — the right way round for a release path, per ADR-0003's fail-loud precedent. The experimental workflow already globbed, so partial-arch runs verify exactly what they published.

## Testing

Logic exercised against a stubbed `gh` for all three cases:

- all assets correct → passes, issues no uploads
- one asset truncated (the real failure) → detects it, re-uploads **only** that asset, converges, passes
- asset absent and upload keeps failing → 3 attempts, then fails the job with `::error::`

Both modified workflows parse as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)