### PR TITLE
Stop the upload guard's retry loop being killed by the runner's errexit

### DIFF
--- a/.github/workflows/create_experimental_release.yml
+++ b/.github/workflows/create_experimental_release.yml
@@ -397,6 +397,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # +e explicitly: Actions runs `run:` blocks under `bash -e`, which would
+          # abort this step the moment a `gh release view` call failed -- i.e. on
+          # exactly the transient API failure the retry loop exists to survive.
+          # Errors are handled per-command below instead.
+          set +e
           set -uo pipefail
           for attempt in 1 2 3; do
             incomplete=()

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -473,6 +473,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # +e explicitly: Actions runs `run:` blocks under `bash -e`, which would
+          # abort this step the moment a `gh release view` call failed -- i.e. on
+          # exactly the transient API failure the retry loop exists to survive.
+          # Errors are handled per-command below instead.
+          set +e
           set -uo pipefail
           for attempt in 1 2 3; do
             incomplete=()

--- a/.github/workflows/make_usb.yml
+++ b/.github/workflows/make_usb.yml
@@ -104,6 +104,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # +e explicitly: Actions runs `run:` blocks under `bash -e`, which would
+          # abort this step the moment a `gh release view` call failed -- i.e. on
+          # exactly the transient API failure the retry loop exists to survive.
+          # Errors are handled per-command below instead.
+          set +e
           set -uo pipefail
           files=(/tmp/fos-usb.img /tmp/fos-usb.img.sha256)
           for attempt in 1 2 3; do


### PR DESCRIPTION
Follow-up to #147, found by actually running it.

The live test of #147 passed, but its log shows how Actions invokes the step:

```
shell: /usr/bin/bash -e {0}
```

`bash -e` is the default, and `set -uo pipefail` does not clear it. The guard's verification call is an assignment from a command substitution:

```bash
got=$(gh release view "$TAG_NAME" --json assets -q ...)
```

Under errexit, a failure there terminates the step immediately. That is exactly the transient API failure the retry loop was written to survive — so the loop would never reach a second attempt, and never emit its `::error::`; the job would just die opaquely on the first blip.

The passing live test did not catch it, and could not have: nothing failed during that run, and the defect only appears on the path the guard exists for. Worth stating plainly, since a green test is easy to mistake for proof.

## Fix

`set +e` explicitly, with a comment, keeping the per-command error handling the loop already does.

## Verified

Under `bash -e` with a `gh` stub that always fails:

| | result |
|---|---|
| before | exits at the first call — no retries, error handler never reached |
| after | all three attempts run, reaches the explicit `::error::` |

All three workflows still parse as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)