### PR TITLE
Fix MBR extended-partition capture and deploy

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -2646,6 +2646,25 @@ savePartition() {
     getPartType "$part"
     local ebrfilename=""
     local swapuuidfilename=""
+    # An extended partition is a container, not a filesystem. Its whole content
+    # is the EBR chain describing the logical partitions inside it, and that
+    # chain is rebuilt from the partition table at deploy -- so all this image
+    # needs is the sidecar marking "there was an extended partition here".
+    #
+    # This has to be tested before the $fstype dispatch below. An extended
+    # partition has no FS_TYPE, so fsTypeSetting always resolves it to "imager",
+    # which matches its own branch first and left the extended-partition case
+    # further down unreachable. The result was a d<disk>p<part>.img holding the
+    # 1 KB EBR window Linux exposes for the container; deploy then wrote it back
+    # over the chain sfdisk had just built, and every logical partition after
+    # the first vanished mid-restore (FOS issue #150).
+    if [[ $parttype == +(0x5|0xf) ]]; then
+        echo " * Not capturing content of extended partition"
+        debugPause
+        EBRFileName "$imagePath" "$disk_number" "$part_number"
+        touch "$ebrfilename"
+        return
+    fi
     case $fstype in
         swap)
             echo " * Saving swap partition UUID"
@@ -2678,34 +2697,24 @@ savePartition() {
             esac
             ;;
         *)
-            case $parttype in
-                0x5|0xf)
-                    echo " * Not capturing content of extended partition"
+            echo " * Using partclone.$fstype"
+            debugPause
+            imgpart="$imagePath/d${disk_number}p${part_number}.img"
+            uploadFormat "$fifoname" "$imgpart"
+            partclone.$fstype -n "Storage Location $storage, Image name $img" -cs $part -O $fifoname -Nf 1 -a0
+            exitcode=$?
+            wait $formatPID 2>/dev/null
+            formatexit=$?
+            [[ $exitcode -eq 0 && ! $formatexit -eq 0 ]] && exitcode=$formatexit
+            case $exitcode in
+                0)
+                    mv ${imgpart}.000 $imgpart >/dev/null 2>&1
+                    echo " * Image Captured"
                     debugPause
-                    EBRFileName "$imagePath" "$disk_number" "$part_number"
-                    touch "$ebrfilename"
                     ;;
                 *)
-                    echo " * Using partclone.$fstype"
-                    debugPause
-                    imgpart="$imagePath/d${disk_number}p${part_number}.img"
-                    uploadFormat "$fifoname" "$imgpart"
-                    partclone.$fstype -n "Storage Location $storage, Image name $img" -cs $part -O $fifoname -Nf 1 -a0
-                    exitcode=$?
-                    wait $formatPID 2>/dev/null
-                    formatexit=$?
-                    [[ $exitcode -eq 0 && ! $formatexit -eq 0 ]] && exitcode=$formatexit
-                    case $exitcode in
-                        0)
-                            mv ${imgpart}.000 $imgpart >/dev/null 2>&1
-                            echo " * Image Captured"
-                            debugPause
-                            ;;
-                        *)
-                            local spaceAvailable=$(getServerDiskSpaceAvailable)
-                            handleError "Failed to complete capture (${FUNCNAME[0]})\n    Args Passed: $*\n    CMD: partclone.$fstype -n \"Storage Location $storage, Image name $img\" -cs -O $fifoname -Nf 1 -a0\n    Exit code: $exitcode\n    Server Disk Space Available: $spaceAvailable"
-                            ;;
-                    esac
+                    local spaceAvailable=$(getServerDiskSpaceAvailable)
+                    handleError "Failed to complete capture (${FUNCNAME[0]})\n    Args Passed: $*\n    CMD: partclone.$fstype -n \"Storage Location $storage, Image name $img\" -cs -O $fifoname -Nf 1 -a0\n    Exit code: $exitcode\n    Server Disk Space Available: $spaceAvailable"
                     ;;
             esac
             ;;
@@ -2741,6 +2750,26 @@ restorePartition() {
     getPartitionNumber "$part"
     echo " * Processing Partition: $part ($part_number)"
     debugPause
+    # Never write an image into an extended partition, whatever the image
+    # happens to contain for it. The device Linux exposes for the container is
+    # just the 1 KB EBR window at its front, so writing anything there destroys
+    # the EBR chain restoreOriginalPartitions/fillDiskWithPartitions has already
+    # rebuilt, and every logical partition after the first disappears -- the
+    # next writeImage then fails with "open /dev/sdaN error(2)".
+    #
+    # Keyed off the partition type rather than off the absence of a
+    # d<disk>p<part>.img, because every image captured before FOS issue #150 was
+    # fixed still carries one. Those are exactly the images that break, so the
+    # check has to override the file (see the ebrfilename fallback below, which
+    # only ever fires when no .img exists).
+    local parttype=""
+    getPartType "$part"
+    if [[ $parttype == +(0x5|0xf) ]]; then
+        echo " * Not deploying content of extended partition"
+        debugPause
+        runPartprobe "$disk"
+        return
+    fi
     case $imgType in
         dd)
             imgpart="$imagePath"

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/procsfdisk.awk
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/procsfdisk.awk
@@ -29,6 +29,36 @@
 # $data is the filename of the output of sfdisk -d
 # cat $data | awk -F, '\
 
+# Comparison function for PROCINFO["sorted_in"], ordering a partition_names
+# traversal by partition number rather than by gawk's hash order.
+#
+# `for (name in partition_names)` has no defined order. That is fatal for an
+# MBR table carrying an extended partition: sfdisk applies a script line by
+# line and derives the partition number from the device name, so a logical
+# (>=5) reaching sfdisk before the extended partition that contains it fails
+# with "Extended partition does not exists. Failed to add logical partition."
+# and the whole apply is abandoned. gawk's hash order happens to match the
+# input order for /dev/sdaN with N <= 9, which is why this only surfaced on
+# tables with ten or more partitions (/dev/sda10 hashes to the front).
+# Ascending partition number is the order sfdisk needs and the order the rest
+# of this script was written assuming.
+#
+# i1/i2 are the array indices (the device names); v1/v2 are unused.
+# n1 and n2 are locally scoped.
+function by_partition_number(i1, v1, i2, v2, n1, n2) {
+    # Same extraction as the parser below, so devices like mmcblk0p10 and
+    # nvme0n1p10 order on their partition number and not on the whole string.
+    n1 = int(gensub(/^.*[^0-9]([0-9]+)/, "\\1", 1, i1));
+    n2 = int(gensub(/^.*[^0-9]([0-9]+)/, "\\1", 1, i2));
+    if (n1 < n2) {
+        return -1;
+    }
+    if (n1 > n2) {
+        return 1;
+    }
+    return 0;
+}
+
 # Checks all partitions for any overlap possibilities.
 # Requires partition_names and partitions.
 # partition_names is an array of all the partition names.
@@ -137,7 +167,15 @@ function check_overlap(partition_names, partitions, new_part_name, new_start, ne
         }
         # Overlap checks.
         if (p_type == 5 || p_type == "f") {
-            if (p_number > 4) {
+            # The partition being tested against is the extended container, so
+            # the question is containment, not overlap: a logical partition
+            # must sit wholly inside it, and anything else must sit wholly
+            # outside. The guard used to read `p_number > 4`, but p_number is
+            # the container's own number and an extended partition is always a
+            # primary (1-4) -- so the containment test never ran and a computed
+            # layout whose logicals spilled out of their container was still
+            # reported "consistent".
+            if (new_part_number > 4) {
                 if (new_start < p_start + extended_margin) {
                     printf("ERROR: new_start < p_start + extended_margin value at (%s).\n", pName);
                     return 1;
@@ -182,12 +220,13 @@ function check_overlap(partition_names, partitions, new_part_name, new_start, ne
 # p_name is locally scoped
 # p_attrs is locally scoped
 # typelabel is locally scoped
+# old_sorted_in is locally scoped
 # Global Scoped variables (meaning not needed to pass to the function:
 # unit the unit type
 # label the device label
 # labelid the device label id
 # device the device itself
-function display_output(partition_names, partitions, pName, p_device, p_start, p_size, p_type, p_flag, p_uuid, p_name, p_attrs, typelabel) {
+function display_output(partition_names, partitions, pName, p_device, p_start, p_size, p_type, p_flag, p_uuid, p_name, p_attrs, typelabel, old_sorted_in) {
     # If unit is not set, or has no value, set to sectors.
     if (!unit) {
         unit = "sectors";
@@ -216,6 +255,11 @@ function display_output(partition_names, partitions, pName, p_device, p_start, p
         printf("sector-size: %d\n", sectorsize);
     }
     printf("\n");
+    # Emit in ascending partition number. sfdisk consumes this file top to
+    # bottom, so an extended partition has to be written before any logical
+    # partition that lives inside it -- see by_partition_number().
+    old_sorted_in = PROCINFO["sorted_in"];
+    PROCINFO["sorted_in"] = "by_partition_number";
     # Iterate our partition names.
     for (pName in partition_names) {
         # Set our p_device variable.
@@ -262,6 +306,7 @@ function display_output(partition_names, partitions, pName, p_device, p_start, p
         # Write new line from partition info.
         printf("\n");
     }
+    PROCINFO["sorted_in"] = old_sorted_in;
     return 0;
 }
 
@@ -391,9 +436,19 @@ function move_partition(partition_names, partitions, args, pName, new_start, new
 # ordered_starts is locally scoped
 # old_sorted_in is locally scoped
 # curr_start is locally scoped
-function fill_disk(partition_names, partitions, args, n, fixed_partitions, original_variable, original_fixed, new_variable, extended_margin, pName, p_type, p_number, p_size, p_minsize, i, partition_starts, ordered_starts, old_sorted_in, curr_start) {
+# ext_name is locally scoped (the extended partition's device name, if any)
+# ext_end is locally scoped
+# p_end is locally scoped
+# logical_count is locally scoped
+function fill_disk(partition_names, partitions, args, n, fixed_partitions, original_variable, original_fixed, new_variable, extended_margin, pName, p_type, p_number, p_size, p_minsize, i, partition_starts, ordered_starts, old_sorted_in, curr_start, ext_name, ext_end, p_end, logical_count) {
     # Used for extended volumes (logical disks)
     extended_margin = 2;
+    # The "find the next partition" scan below infers a partition's original
+    # size from where its neighbour starts, so the partition_names traversals
+    # need a defined order -- ascending partition number, the order the dump
+    # was written in. See by_partition_number().
+    old_sorted_in = PROCINFO["sorted_in"];
+    PROCINFO["sorted_in"] = "by_partition_number";
     # Ensure we start at 0 for original sizes.
     original_variable = 0;
     # Fixed should be MIN_START.
@@ -535,6 +590,15 @@ function fill_disk(partition_names, partitions, args, n, fixed_partitions, origi
         if (match(fixedList, regex)) {
             continue;
         }
+        # An extended partition holds no data of its own -- it is a container
+        # whose extent is defined by the logical partitions inside it. Scaling
+        # its captured size by the same percentage as a data partition is what
+        # made the container run off the end of the target disk. Its size is
+        # derived from where the logicals actually land, after the start
+        # positions below have been assigned.
+        if (label != "gpt" && (p_type == 5 || p_type == "f")) {
+            continue;
+        }
         # Get's the percentage increase/decrease and makes adjustment.
         p_size = new_variable * p_size / original_variable;
         # If the new size is smaller than the minsize reset the size to at least equal the min size.
@@ -543,18 +607,15 @@ function fill_disk(partition_names, partitions, args, n, fixed_partitions, origi
         }
         # Ensure we're aligned.
         p_size -= (p_size % int(SECTOR_SIZE));
-        if (label != "gpt") {
-            if (p_type == 5 || p_type == "f") {
-                p_size += extended_margin;
-            }
-        }
         # Ensure the partition size is setup.
         partitions[pName, "size"] = p_size;
     }
     # Assign the new start positions.
     asort(partition_starts, ordered_starts, "@ind_num_asc");
-    # sort our stuff.
-    old_sorted_in = PROCINFO["sorted_in"];
+    # asort() indexes ordered_starts 1..n in ascending start order, and the loop
+    # below accumulates curr_start as it walks, so this traversal must follow
+    # that index order rather than the by-partition-number order used above.
+    PROCINFO["sorted_in"] = "@ind_num_asc";
     # curr-start must be set to MIN_START initially.
     curr_start = int(MIN_START);
     # Prior size should start as 0
@@ -597,8 +658,27 @@ function fill_disk(partition_names, partitions, args, n, fixed_partitions, origi
             if (p_type == "5" || p_type == "f") {
                 curr_start += int(MIN_START) - extended_margin;
                 partitions[pName, "start"] = curr_start;
+                # Remember the container so its size can be derived once every
+                # logical partition inside it has been placed.
+                ext_name = pName;
                 curr_start += extended_margin;
+                logical_count = 0;
                 continue;
+            }
+            # Every logical partition is introduced by its own EBR sector,
+            # which lives in the gap immediately before it. The first logical
+            # gets that gap from the extended partition's own placement above
+            # (the container starts MIN_START - extended_margin early, so the
+            # first logical lands MIN_START past the previous partition). Each
+            # later logical needs a fresh gap of its own -- loop one already
+            # reserves MIN_START per logical in original_fixed, but nothing was
+            # spending it, so the logicals were packed end to end with nowhere
+            # to put their EBRs and sfdisk ran out of free sectors.
+            if (p_number > 4) {
+                if (logical_count > 0) {
+                    curr_start += int(MIN_START);
+                }
+                logical_count++;
             }
         }
         p_start = curr_start;
@@ -622,10 +702,32 @@ function fill_disk(partition_names, partitions, args, n, fixed_partitions, origi
         prior_size = p_size;
         prior_start = p_start;
     }
+    # Size the extended container to exactly span the logical partitions that
+    # were just placed inside it. Doing it here rather than in the sizing loop
+    # means the container automatically follows the clamp applied to the last
+    # logical above, so it can never extend past disk_end.
+    if (label != "gpt" && ext_name != "") {
+        ext_end = 0;
+        for (pName in partition_names) {
+            if (int(partitions[pName, "number"]) <= 4) {
+                continue;
+            }
+            p_end = int(partitions[pName, "start"]) + int(partitions[pName, "size"]);
+            if (p_end > ext_end) {
+                ext_end = p_end;
+            }
+        }
+        # An extended partition with no logicals inside it keeps its captured
+        # size; there is nothing to derive an extent from.
+        if (ext_end > int(partitions[ext_name, "start"])) {
+            partitions[ext_name, "size"] = ext_end - int(partitions[ext_name, "start"]);
+        }
+    }
     # Set our lastlba
     if (firstlba) {
         lastlba = int(diskSize) - firstlba;
     }
+    PROCINFO["sorted_in"] = old_sorted_in;
     # Check for any overlaps.
     return check_all_partitions(partition_names, partitions);
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,7 @@ tests/golden/run.sh print     # dump current output to stdout, no comparison
 
 tests/checks/sector-size.sh   # validateImageSectorSize() refusal/reformat behavior
 tests/checks/fill-engine.sh   # sfdisk fill engine: 4Kn rescaling, GPT clamp, abort-on-unusable-table
+tests/checks/mbr-extended.sh  # MBR extended/logical layouts: emission order, EBR gaps, container sizing
 tests/checks/wipe.sh          # wipeDisk() erase-primitive-per-device-class correctness
 tests/checks/lvm.sh           # per-LV LVM capture/deploy/resize paths
 tests/checks/secureboot.sh    # firmware-state detection, non-interactive MOK staging, Setup Mode db writes
@@ -284,6 +285,24 @@ and add a new ADR for any similarly hard-to-reverse decision:
   reachable (that is what the `falling back to CSI` notice reports), and
   `pcie_aspm=off` on the command line does nothing because the `__setup()` that
   registers it is compiled out. Guarded by `tests/checks/pcie-aspm-config.sh`.
+- **0014 — MBR extended partitions.** Two invariants for a DOS table carrying an
+  extended partition. First, **`procsfdisk.awk` must emit partitions in ascending
+  partition number**: sfdisk applies a script top to bottom and takes the number
+  from the device name, so a logical reaching it before its container aborts the
+  whole write. `for (name in array)` is unordered in awk and only *looked* right
+  because gawk's hash order matches insertion order for `/dev/sdaN` while N <= 9
+  — ten partitions is where it broke. Every `partition_names` traversal is now
+  ordered explicitly; the `ordered_starts` walk is pinned to `@ind_num_asc`
+  because it accumulates `curr_start` and needs asort's index order instead.
+  Second, **an extended partition is a container, never content**: Linux exposes
+  it as the ~1 KB EBR window, so imaging it and writing it back destroys the EBR
+  chain and every logical after the first disappears mid-deploy. Capture tests
+  for it *before* the `$fstype` dispatch (it has no filesystem, so
+  `fsTypeSetting` calls it `imager` and the old check below that was
+  unreachable); deploy keys its skip off the partition **type**, not off a
+  missing `.img`, because every image captured before this fix still carries one.
+  The container's size is derived from where its logicals land, never scaled.
+  Guarded by `tests/checks/mbr-extended.sh`.
 
 General conventions to preserve when editing `funcs.sh`/`partition-funcs.sh`:
 

--- a/docs/adr/0014-mbr-extended-partitions.md
+++ b/docs/adr/0014-mbr-extended-partitions.md
@@ -1,0 +1,158 @@
+# An extended partition is a container: order the table by partition number, and never image the container
+
+FOG could neither capture nor deploy an MBR disk carrying an extended partition
+with logical partitions inside it
+([#150](https://github.com/FOGProject/fos/issues/150)). The reporter's disk had
+ten partitions — three primaries, the third an LBA extended, plus six logicals —
+and capture died before a single byte was uploaded:
+
+```
+>>> Created a new DOS (MBR) disklabel with disk identifier 0xc4eae1bb.
+/dev/sda1: Extended partition does not exists. Failed to add logical partition.
+Failed to add #1 partition: Invalid argument
+Leaving.
+```
+
+That is two independent defects wearing one bug report. Both are recorded here
+because both are the kind of mistake that looks correct in review and in most
+testing.
+
+## 1. The emitted partition table was in gawk's hash order
+
+`display_output()` in `procsfdisk.awk` walked the partition array with
+
+```awk
+for (pName in partition_names) {
+```
+
+`for (i in array)` has **no defined order** in awk. `sfdisk` consumes a script
+top to bottom and derives each partition's number from the device name on the
+line, so a logical partition (>= 5) reaching `sfdisk` before the extended
+partition that contains it fails in `add_logical()` with the message above, and
+the entire write is abandoned. The device named in that message is not the
+offending line — it is `sfdisk`'s prompt for the next slot it was going to fill,
+which is why the error says `/dev/sda1` about a fault caused by `/dev/sda10`.
+
+**This hid for years because gawk's hash order happens to match insertion order
+for `/dev/sdaN` while N <= 9.** Every table with nine or fewer partitions came
+out correct by accident. Add a tenth and `/dev/sda10` hashes to the front, and
+the accident stops. There was never a case where the code was right; there were
+only inputs whose hash order flattered it.
+
+The fix orders every `partition_names` traversal by partition number
+(`by_partition_number()` via `PROCINFO["sorted_in"]`), which is both what sfdisk
+requires and what the rest of the script was written assuming. Two traversals
+needed care rather than a blanket setting:
+
+- `fill_disk()`'s "find the next partition" scan infers a partition's original
+  size from where its neighbour starts, so it needs the same by-number order.
+- the `ordered_starts` walk that assigns new start positions accumulates
+  `curr_start` as it goes and must follow `asort()`'s ascending *index* order.
+  It was relying on hash order too, so it is now pinned explicitly to
+  `@ind_num_asc` rather than left to chance.
+
+Because capture's shrink step writes a resized table back to the source disk,
+this defect broke **capture**, not just deploy — which is why the reporter never
+got an image at all.
+
+### Two more, found on the deploy side of the same engine
+
+- **No room for the EBRs.** Each logical partition is introduced by an EBR
+  sector living in the gap immediately before it. `fill_disk()` reserved
+  `MIN_START` per logical in `original_fixed`, but nothing ever *spent* it when
+  assigning starts, so the fill packed logicals end to end and sfdisk hit
+  `No free sectors available`. The reservation and the spending now agree.
+- **The container was scaled like data.** An extended partition holds no
+  content of its own; its extent is defined by what is inside it. `fill_disk()`
+  ran its captured size through the same proportional grow/shrink as a
+  filesystem partition, which walked the container's end past the end of the
+  target disk on any grow-to-fit deploy. Its size is now **derived** after the
+  logicals are placed, as `last_logical_end - ext_start`. Deriving it late also
+  means it inherits the disk-end clamp applied to the last logical for free, so
+  the container can never extend past `disk_end`.
+
+### The consistency check that never ran
+
+`check_overlap()` has a branch meant to assert that a logical partition sits
+wholly inside its container. It was guarded on `p_number > 4` — where `p_number`
+is the *container's* own partition number, and an extended partition is always a
+primary, so it is never > 4. The check has therefore never executed. It is now
+guarded on `new_part_number > 4`, the number of the partition being tested.
+
+This is a previously-dead safety net going live, and that is deliberate: with
+the fill engine corrected the check cannot fire on a table this code produces,
+so its only job is to catch the next regression in this area before it reaches
+a disk (the same reasoning as [ADR-0003](0003-fail-loud-on-partition-table-failure.md)).
+
+## 2. The extended partition was captured, and restored, as content
+
+Linux exposes an extended partition as a block device covering only the ~1 KB
+EBR window at the front of the container. Anything written to that device lands
+on the EBR chain.
+
+`savePartition()` dispatched on `$fstype` before testing the partition type:
+
+```bash
+case $fstype in
+    ...
+    imager)     # <-- an extended partition always lands here
+        ...
+    *)
+        case $parttype in
+            0x5|0xf)   # <-- unreachable
+```
+
+An extended partition has no filesystem, so `fsTypeSetting()` resolves it to
+`imager` and the `imager` arm matched first. The extended-partition arm below it
+could never be reached. FOG therefore captured the container's EBR window as a
+`d<disk>p<part>.img`, and on deploy `restorePartition()` wrote it back — over the
+chain `fillDiskWithPartitions` had just built from the partition table. Every
+logical partition after the first ceased to exist mid-restore, and the next
+`writeImage` failed:
+
+```
+ * Restoring EBR for (/dev/sda3).....................Done
+ * Processing Partition: /dev/sda5 (5)
+partclone.c,open_target,1818: open /dev/sda6 error(2)
+```
+
+which is precisely what the reporter described from his own manual workaround.
+
+Capture now tests for the container **before** the `$fstype` dispatch and writes
+only the `.ebr` sidecar.
+
+Deploy's guard is keyed off the **partition type, not off the absence of a
+`.img`**, and that distinction is the load-bearing part. The pre-existing
+fallback only consulted the `.ebr` sidecar when no image file was found — but
+*every image captured before this fix still carries one*, and those are exactly
+the images that break. A guard that defers to the file would keep failing on the
+entire existing image library. The type is authoritative; the file is not.
+
+## Consequences
+
+- Images captured before this fix keep a stale `d<disk>p<part>.img` for their
+  extended partition. They do not need re-capturing: the deploy-side guard
+  ignores it. Re-capturing does remove it.
+- `partitionIsDosExtended()` in `funcs.sh` is left alone. It has no callers and
+  its `dos)` branch returns "no" for exactly the scheme it is meant to detect,
+  so it is inverted as well as dead; the live paths use the `getPartType` +
+  `0x5|0xf` test that was already in the code beside them. Removing it is a
+  separate cleanup.
+- `tests/checks/mbr-extended.sh` covers all of the above. Where a real `sfdisk`
+  is on the host it also *applies* each computed table to a sparse file, which
+  is the only assertion that proves sfdisk accepts the layout rather than that
+  the numbers look plausible. 10 of its cases fail against the pre-fix tree.
+
+## Validation
+
+Verified end to end against a FOG 1.6 server, not only in the harness: a 16 GiB
+MBR disk with the reporter's shape (3 primaries including an LBA extended, plus
+6 logicals) was captured, then deployed onto a 24 GiB disk. All ten partitions
+came back, every logical inside the container with its EBR gap intact, and all
+eight payload checksums matched the source byte for byte.
+
+The lab disk was synthetic — built with `sfdisk` + `mke2fs -d` rather than
+installed by an OS — so it exercises the geometry and the data path but not, for
+example, a bootloader in the extended chain or a vendor's unusual EBR layout.
+The reporter's own disk is a Debian 13 install; a pass there is still worth
+having.

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,6 +45,16 @@ tests/checks/fill-engine.sh   # the whole-disk fill engine (processSfdisk +
                               # alive, the GPT backup-header clamp holds, and an
                               # unusable computed table aborts instead of being
                               # written
+tests/checks/mbr-extended.sh  # MBR tables carrying an extended partition with
+                              # logicals inside it (issue #150): the emitted
+                              # table is ordered by partition number so sfdisk
+                              # never meets a logical before its container, each
+                              # logical keeps a gap for its EBR, the container is
+                              # sized from its contents rather than scaled, and
+                              # savePartition/restorePartition treat it as a
+                              # container rather than partclone'ing it. Where a
+                              # real sfdisk is present each computed table is
+                              # also applied to a sparse file
 tests/checks/wipe.sh          # wipeDisk() issues the right erase primitive per
                               # device class (NVMe/SSD/HDD) and mode
                               # (fast/normal/full), never issues an `nvme format`

--- a/tests/checks/mbr-extended.sh
+++ b/tests/checks/mbr-extended.sh
@@ -1,0 +1,412 @@
+#!/bin/bash
+#
+# Assertion harness for MBR tables carrying an extended partition with logical
+# partitions inside it (FOS issue #150).
+#
+#   tests/checks/mbr-extended.sh   # run all cases, exit non-zero on any failure
+#
+# sfdisk consumes a script top to bottom and takes each partition number from
+# the device name on the line, so an extended-partition layout only survives a
+# round trip if the emitted table obeys three rules that nothing else in the
+# suite covers:
+#
+#   1. Emission order. procsfdisk.awk collects partitions in an associative
+#      array and display_output() walked it with `for (name in array)`, which
+#      gawk leaves unordered. It happens to match input order for /dev/sdaN
+#      with N <= 9, so the bug hid until a table had ten partitions and
+#      /dev/sda10 hashed to the front -- sfdisk then met a logical partition
+#      before the extended one that contains it and abandoned the whole write
+#      with "Extended partition does not exists. Failed to add logical
+#      partition." That killed capture (the shrink step applies a resized
+#      table) before a single byte was uploaded.
+#
+#   2. EBR room between logicals. Each logical partition is introduced by an
+#      EBR sector living in the gap immediately before it. fill_disk() reserved
+#      MIN_START per logical in its fixed-space budget but never spent it when
+#      assigning starts, so the fill packed logicals end to end and sfdisk hit
+#      "No free sectors available".
+#
+#   3. The extended partition is a container, not data. Its size has to be
+#      derived from where its logicals land. Scaling it proportionally like a
+#      data partition (what fill_disk used to do) walked its end past the end
+#      of the disk on any grow-to-fit deploy.
+#
+# Mechanism mirrors tests/checks/fill-engine.sh: source a sandbox copy of
+# partition-funcs.sh with the awk path rewritten to the in-tree script, and
+# PATH-shadow blockdev with a deterministic stub. Where a real sfdisk is
+# available the computed table is additionally applied to a sparse file, which
+# is the only assertion that proves sfdisk itself accepts the layout.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_LIB="$HERE/../../Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib"
+
+[[ -f $REPO_LIB/partition-funcs.sh ]] || { echo "ERROR: cannot find partition-funcs.sh under $REPO_LIB" >&2; exit 2; }
+[[ -f $REPO_LIB/procsfdisk.awk ]] || { echo "ERROR: cannot find procsfdisk.awk under $REPO_LIB" >&2; exit 2; }
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+REALAWK="$REPO_LIB/procsfdisk.awk"
+sed -e "s#/usr/share/fog/lib/procsfdisk\.awk#awk -f $REALAWK#g" \
+    "$REPO_LIB/partition-funcs.sh" > "$SANDBOX/partition-funcs.sh"
+
+STUBBIN="$SANDBOX/bin"
+mkdir -p "$STUBBIN"
+cat > "$STUBBIN/blockdev" <<'EOF'
+#!/bin/bash
+case "$1" in
+    --getsz)   printf '%s\n' "$FAKE_GETSZ" ;;
+    --getss)   printf '%s\n' "$FAKE_GETSS" ;;
+    --getpbsz) printf '%s\n' "$FAKE_GETPBSZ" ;;
+esac
+exit 0
+EOF
+chmod +x "$STUBBIN/blockdev"
+
+PASS=0
+FAIL=0
+SKIP=0
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; [[ -n $2 ]] && echo "      $2"; FAIL=$((FAIL + 1)); }
+skip() { echo "SKIP: $1"; SKIP=$((SKIP + 1)); }
+
+# --- parse helpers over $OUT (the emitted "sfdisk -d" table) ---
+pstart() { printf '%s\n' "$OUT" | sed -n "s#^$1 : start= *\([0-9]\{1,\}\).*#\1#p" | head -1; }
+psize()  { printf '%s\n' "$OUT" | sed -n "s#^$1 : .*size= *\([0-9]\{1,\}\).*#\1#p" | head -1; }
+pend()   { echo $(( $(pstart "$1") + $(psize "$1") )); }
+# The partition numbers of the emitted lines, in emission order.
+porder() { printf '%s\n' "$OUT" | sed -n 's#^/dev/sda\([0-9]\{1,\}\) : .*#\1#p' | tr '\n' ' '; }
+
+# run_proc <dumpfile> <action> <target> <sizePos> <getsz> <fixed> -- drive the real
+# processSfdisk; leaves the emitted table in $OUT and its exit status in $RC.
+run_proc() {
+    local dump="$1" action="$2" target="$3" sizepos="$4" getsz="$5" fixed="$6"
+    OUT="$(
+        set +u
+        export PATH="$STUBBIN:$PATH"
+        export FAKE_GETSZ="$getsz" FAKE_GETSS=512 FAKE_GETPBSZ=512
+        . "$SANDBOX/partition-funcs.sh"
+        handleError() { echo "ABORT: $*"; exit 1; }
+        handleWarning() { :; }
+        getPartBlockSize() { printf -v "$2" '%s' 512; }
+        runPartprobe() { :; }
+        majorDebugEcho() { :; }; majorDebugPause() { :; }; majorDebugShowCurrentPartitionTable() { :; }
+        ismajordebug=0
+        disk="/dev/sda"                        # processSfdisk reads the global $disk
+        processSfdisk "$dump" "$action" "$target" "$sizepos" "$fixed" "$dump"
+    )"
+    RC=$?
+}
+
+# apply_for_real <name> -- write $OUT to a sparse file with a real sfdisk. Proves
+# the layout is one sfdisk will actually accept, which is the failure the issue
+# reported. Skipped where sfdisk or a sparse file is unavailable.
+apply_for_real() {
+    local name="$1" sectors="$2" img="$SANDBOX/apply.img" out
+    if ! command -v sfdisk >/dev/null 2>&1 || ! command -v truncate >/dev/null 2>&1; then
+        skip "$name (no sfdisk/truncate on this host)"
+        return
+    fi
+    rm -f "$img"
+    if ! truncate -s $(( sectors * 512 )) "$img" 2>/dev/null; then
+        skip "$name (cannot create a sparse file in $SANDBOX)"
+        return
+    fi
+    # Retarget the table at the image file and drop the awk's "# ..." commentary,
+    # which sfdisk would report as an unknown script header.
+    printf '%s\n' "$OUT" | grep -v '^#' | sed "s#/dev/sda#$img#g" > "$SANDBOX/apply.table"
+    out="$(sfdisk "$img" < "$SANDBOX/apply.table" 2>&1)"
+    local rc=$?
+    rm -f "$img"
+    if [[ $rc -eq 0 && $out != *"Failed to add"* && $out != *"Leaving."* ]]; then
+        pass "$name (real sfdisk accepted the table)"
+    else
+        fail "$name" "sfdisk rc=$rc: $(printf '%s' "$out" | grep -iE 'fail|error|leaving' | tr '\n' '|')"
+    fi
+}
+
+# The layout from issue #150: three primaries (the third an LBA extended) plus
+# six logicals, ten partitions in total on an 80 GiB disk.
+DISK80=167772160
+cat > "$SANDBOX/d.ext" <<'EOF'
+label: dos
+label-id: 0xc4eae1bb
+device: /dev/sda
+unit: sectors
+sector-size: 512
+
+/dev/sda1 : start=        2048, size=     2097152, type=b
+/dev/sda2 : start=     2099200, size=     4194304, type=83
+/dev/sda3 : start=     6293504, size=   161478656, type=f
+/dev/sda5 : start=     6295552, size=    21116928, type=83
+/dev/sda6 : start=    27414528, size=    50223104, type=83
+/dev/sda7 : start=    77639680, size=    19529728, type=83
+/dev/sda8 : start=    97171456, size=     9762816, type=83
+/dev/sda9 : start=   106936320, size=    11616256, type=83
+/dev/sda10 : start=   118554624, size=    49217536, type=83
+EOF
+
+# ---------------------------------------------------------------------------
+# 1. Capture path (resize). The shrink step writes the resized table back to the
+#    source disk, so its emission order is what actually broke the upload.
+run_proc "$SANDBOX/d.ext" resize /dev/sda6 10000000 "$DISK80" ""
+if [[ $RC -eq 0 && "$(porder)" == "1 2 3 5 6 7 8 9 10 " ]]; then
+    pass "resize emits ascending partition numbers (extended before its logicals)"
+else
+    fail "resize emission order" "rc=$RC order='$(porder)'
+$OUT"
+fi
+apply_for_real "resize output applies to a real disk" "$DISK80"
+
+# 2. The resize itself still lands on the requested partition, and only on it.
+if [[ $(psize /dev/sda6) -eq $(( 10000000 / 512 )) && $(psize /dev/sda5) -eq 21116928 \
+      && $(psize /dev/sda10) -eq 49217536 ]]; then
+    pass "resize shrinks only the target logical partition"
+else
+    fail "resize target" "sda6=$(psize /dev/sda6) sda5=$(psize /dev/sda5) sda10=$(psize /dev/sda10)"
+fi
+
+# ---------------------------------------------------------------------------
+# check_extended_layout -- shared assertions for a filled table: emission order,
+# every logical inside the container, the container ending exactly at the last
+# logical, an EBR gap before every logical, and nothing past the end of the disk.
+check_extended_layout() {
+    local name="$1" disksize="$2"
+    local errs="" prev_end=0 n last_end=0
+    [[ "$(porder)" == "1 2 3 5 6 7 8 9 10 " ]] || errs="$errs order='$(porder)';"
+    local ext_start=$(pstart /dev/sda3) ext_end=$(pend /dev/sda3)
+    for n in 5 6 7 8 9 10; do
+        local s=$(pstart "/dev/sda$n") e=$(pend "/dev/sda$n")
+        [[ $s -ge $ext_start && $e -le $ext_end ]] || errs="$errs sda$n ($s-$e) outside extended ($ext_start-$ext_end);"
+        # Every logical needs at least one free sector before it for its EBR:
+        # the first inside the container, the rest after the previous logical.
+        local floor=$ext_start
+        [[ $prev_end -gt 0 ]] && floor=$prev_end
+        [[ $s -gt $floor ]] || errs="$errs sda$n start $s leaves no EBR room after $floor;"
+        prev_end=$e
+        last_end=$e
+    done
+    [[ $ext_end -eq $last_end ]] || errs="$errs extended ends $ext_end, last logical ends $last_end;"
+    [[ $ext_end -le $disksize ]] || errs="$errs extended ends $ext_end past disk $disksize;"
+    if [[ $RC -eq 0 && $OUT == *"consistent"* && $OUT != *ERROR* && -z $errs ]]; then
+        pass "$name"
+    else
+        fail "$name" "rc=$RC $errs
+$OUT"
+    fi
+}
+
+# 3. Deploy onto a larger disk: everything grows to fit and the container follows.
+DISK120=251658240
+run_proc "$SANDBOX/d.ext" filldisk /dev/sda "$DISK120" "$DISK120" "1"
+check_extended_layout "filldisk onto a larger disk keeps a usable extended layout" "$DISK120"
+apply_for_real "filldisk (larger disk) output applies to a real disk" "$DISK120"
+
+# 4. Deploy onto an identical disk: the source layout has to come back intact.
+run_proc "$SANDBOX/d.ext" filldisk /dev/sda "$DISK80" "$DISK80" "1"
+check_extended_layout "filldisk onto an identical disk keeps a usable extended layout" "$DISK80"
+if [[ $(pstart /dev/sda5) -eq 6295552 && $(psize /dev/sda5) -eq 21116928 \
+      && $(pstart /dev/sda10) -eq 118554624 && $(psize /dev/sda10) -eq 49217536 ]]; then
+    pass "filldisk onto an identical disk reproduces the captured logical partitions"
+else
+    fail "filldisk identical-disk fidelity" "sda5=$(pstart /dev/sda5)+$(psize /dev/sda5) sda10=$(pstart /dev/sda10)+$(psize /dev/sda10)"
+fi
+apply_for_real "filldisk (identical disk) output applies to a real disk" "$DISK80"
+
+# 5. Deploy onto a disk the image cannot fit: abort rather than write a table
+#    whose partitions run off the end (ADR-0003).
+DISK40=83886080
+run_proc "$SANDBOX/d.ext" filldisk /dev/sda "$DISK40" "$DISK40" "1"
+if [[ $RC -ne 0 && $OUT == *ERROR* ]]; then
+    pass "filldisk onto a too-small disk exits non-zero instead of emitting a bad table"
+else
+    fail "filldisk too-small disk should fail loud" "rc=$RC
+$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. The nine-partition case that always worked must keep working -- this is the
+#    layout gawk's hash order happened to emit in the right sequence, so it is
+#    the regression guard for the ordering change.
+cat > "$SANDBOX/d.ext9" <<'EOF'
+label: dos
+label-id: 0xc4eae1bb
+device: /dev/sda
+unit: sectors
+sector-size: 512
+
+/dev/sda1 : start=        2048, size=     2097152, type=b
+/dev/sda2 : start=     2099200, size=     4194304, type=83
+/dev/sda3 : start=     6293504, size=   161478656, type=f
+/dev/sda5 : start=     6295552, size=    21116928, type=83
+/dev/sda6 : start=    27414528, size=    50223104, type=83
+/dev/sda7 : start=    77639680, size=    19529728, type=83
+/dev/sda8 : start=    97171456, size=     9762816, type=83
+/dev/sda9 : start=   106936320, size=    60835840, type=83
+EOF
+run_proc "$SANDBOX/d.ext9" resize /dev/sda6 10000000 "$DISK80" ""
+if [[ $RC -eq 0 && "$(porder)" == "1 2 3 5 6 7 8 9 " ]]; then
+    pass "nine-partition extended layout still emits in order"
+else
+    fail "nine-partition emission order" "rc=$RC order='$(porder)'
+$OUT"
+fi
+apply_for_real "nine-partition resize output applies to a real disk" "$DISK80"
+
+# ---------------------------------------------------------------------------
+# 7. Containment backstop. check_overlap() is meant to reject a logical
+#    partition that does not sit wholly inside its extended container, but the
+#    test was guarded on the container's own partition number being > 4 -- which
+#    an extended partition, always a primary, never is. With the guard fixed, a
+#    resize that would push a logical past the end of its container is refused
+#    (resize_partition leaves the size alone) instead of being emitted.
+cat > "$SANDBOX/d.small" <<'EOF'
+label: dos
+label-id: 0xc4eae1bb
+device: /dev/sda
+unit: sectors
+sector-size: 512
+
+/dev/sda1 : start=        2048, size=     2097152, type=b
+/dev/sda3 : start=     6293504, size=    20000000, type=f
+/dev/sda5 : start=     6295552, size=    10000000, type=83
+EOF
+# 20000000 * 512 requested for sda5 -> 20000000 sectors, ending 26295552, which
+# is 2048 sectors past the container's end (6293504 + 20000000 = 26293504).
+run_proc "$SANDBOX/d.small" resize /dev/sda5 $(( 20000000 * 512 )) "$DISK80" ""
+if [[ $(psize /dev/sda5) -eq 10000000 ]]; then
+    pass "resize past the end of the extended container is refused"
+else
+    fail "extended containment backstop" "sda5 size=$(psize /dev/sda5) (expected the original 10000000)
+$OUT"
+fi
+
+# A resize that stays inside the container is still allowed.
+run_proc "$SANDBOX/d.small" resize /dev/sda5 $(( 15000000 * 512 )) "$DISK80" ""
+if [[ $(psize /dev/sda5) -eq 15000000 ]]; then
+    pass "resize that stays inside the extended container is allowed"
+else
+    fail "in-container resize" "sda5 size=$(psize /dev/sda5) (expected 15000000)
+$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# The extended partition is a container, not content (funcs.sh).
+#
+# Linux exposes an extended partition as the 1 KB EBR window at the front of the
+# container, so anything written there lands on the EBR chain. savePartition
+# used to reach it: an extended partition has no FS_TYPE, fsTypeSetting resolves
+# that to "imager", and the imager branch matched before the extended-partition
+# branch further down -- so the container was captured as a d<disk>p<part>.img
+# and restorePartition wrote it back over the chain sfdisk had just built,
+# taking every logical partition after the first with it.
+#
+# These cases drive the real savePartition/restorePartition out of funcs.sh with
+# blkid stubbed to describe an extended partition (no FS_TYPE, PART_ENTRY_TYPE
+# 0xf) and partclone stubbed to record any invocation.
+# ---------------------------------------------------------------------------
+
+FUNCS_OK=1
+[[ -f $REPO_LIB/funcs.sh ]] || FUNCS_OK=0
+if [[ $FUNCS_OK -eq 0 ]]; then
+    skip "funcs.sh extended-partition cases (funcs.sh not found)"
+else
+sed -e "s#^\. /usr/share/fog/lib/partition-funcs\.sh#. $SANDBOX/partition-funcs.sh#" \
+    "$REPO_LIB/funcs.sh" > "$SANDBOX/funcs.sh"
+cp "$REPO_LIB/partition-funcs.sh" "$SANDBOX/partition-funcs.sh"
+
+CALLS="$SANDBOX/calls"
+IMGDIR="$SANDBOX/img"
+mkdir -p "$IMGDIR"
+
+# blkid: fsTypeSetting reads FS_TYPE, getPartType reads PART_ENTRY_TYPE. The map
+# pairs a device with "<fstype-or-none> <parttype>"; "none" emits no FS_TYPE at
+# all, which is what a real extended partition looks like.
+cat > "$STUBBIN/blkid" <<'EOF'
+#!/bin/bash
+for last in "$@"; do :; done
+fs=$(awk -v d="$last" '$1==d {print $2}' "$SANDBOX/blkid.map")
+pt=$(awk -v d="$last" '$1==d {print $3}' "$SANDBOX/blkid.map")
+[[ -n $fs && $fs != none ]] && echo "ID_FS_TYPE=$fs"
+[[ -n $pt ]] && echo "ID_PART_ENTRY_TYPE=$pt"
+exit 0
+EOF
+chmod +x "$STUBBIN/blkid"
+
+for pc in partclone.extfs partclone.imager partclone.restore; do
+    cat > "$STUBBIN/$pc" <<'EOF'
+#!/bin/bash
+echo "${0##*/} $*" >> "$CALLS"
+out=""; prev=""
+for a in "$@"; do [[ $prev == "-O" ]] && out="$a"; prev="$a"; done
+[[ -n $out ]] && echo "IMGDATA" > "$out"
+exit 0
+EOF
+    chmod +x "$STUBBIN/$pc"
+done
+
+printf '/dev/sda3 none 0xf\n/dev/sda6 ext4 0x83\n' > "$SANDBOX/blkid.map"
+
+# run_funcs <shell snippet> -- source the sandboxed funcs.sh and evaluate it,
+# leaving the recorded external calls in $CALLS and the output in $OUT.
+run_funcs() {
+    : > "$CALLS"
+    OUT="$(
+        set +u
+        export PATH="$STUBBIN:$PATH"
+        export SANDBOX CALLS
+        . "$SANDBOX/funcs.sh"
+        handleError() { echo "ABORT: $*"; exit 1; }
+        # Record rather than perform the two things a partition restore does.
+        writeImage() { echo "writeImage $*" >> "$CALLS"; }
+        runPartprobe() { :; }
+        uploadFormat() { :; }
+        getServerDiskSpaceAvailable() { echo "lots"; }
+        imgFormat=5; imgPartitionType="all"; imgType="n"; osid=50
+        storage="STUBSTORE"; img="STUBIMG"
+        eval "$1"
+        echo "RETURNED"
+    )"
+}
+
+# 8. Capture: the container gets a sidecar, and partclone is never invoked on it.
+run_funcs 'savePartition /dev/sda3 1 "'"$IMGDIR"'"'
+if [[ $OUT == *"Not capturing content of extended partition"* ]] \
+   && [[ -e $IMGDIR/d1p3.ebr ]] && ! grep -q "^partclone" "$CALLS" 2>/dev/null; then
+    pass "savePartition writes only the EBR sidecar for an extended partition"
+else
+    fail "savePartition on an extended partition" "ebr=$([[ -e $IMGDIR/d1p3.ebr ]] && echo yes || echo no) calls='$(tr '\n' '|' < "$CALLS")' out=$(tr '\n' '|' <<<"$OUT")"
+fi
+
+# 9. A real filesystem on a logical partition still goes through partclone.
+run_funcs 'savePartition /dev/sda6 1 "'"$IMGDIR"'"'
+if grep -q "^partclone.extfs" "$CALLS" 2>/dev/null; then
+    pass "savePartition still captures a logical ext partition with partclone"
+else
+    fail "savePartition on a normal logical partition" "calls='$(tr '\n' '|' < "$CALLS")'"
+fi
+
+# 10. Deploy: an image that still carries a d1p3.img for the container -- every
+#     image captured before this fix does -- must not have it written back.
+: > "$IMGDIR/d1p3.img"
+run_funcs 'restorePartition /dev/sda3 1 "'"$IMGDIR"'" ""'
+if [[ $OUT == *"Not deploying content of extended partition"* ]] \
+   && ! grep -q "^writeImage" "$CALLS" 2>/dev/null; then
+    pass "restorePartition refuses to write an image into an extended partition"
+else
+    fail "restorePartition on an extended partition" "calls='$(tr '\n' '|' < "$CALLS")' out=$(tr '\n' '|' <<<"$OUT")"
+fi
+
+# 11. A normal partition still gets its image written.
+: > "$IMGDIR/d1p6.img"
+run_funcs 'restorePartition /dev/sda6 1 "'"$IMGDIR"'" ""'
+if grep -q "^writeImage .*d1p6.img" "$CALLS" 2>/dev/null; then
+    pass "restorePartition still writes the image for a logical partition"
+else
+    fail "restorePartition on a normal logical partition" "calls='$(tr '\n' '|' < "$CALLS")'"
+fi
+fi
+
+echo "----"
+echo "$PASS passed, $FAIL failed, $SKIP skipped"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Fixes #150. Capture and deploy both fail on an MBR disk carrying an extended
partition with logicals inside it. That turned out to be two independent
defects, each reproduced rather than reasoned about.

## 1. The emitted partition table was in gawk's hash order

`display_output()` in `procsfdisk.awk` walked the partition array with
`for (pName in partition_names)`, which has no defined order. sfdisk consumes a
script top to bottom and derives each partition's number from the device name on
the line, so a logical partition reaching sfdisk before the extended partition
that contains it dies in `add_logical()`:

```
/dev/sda1: Extended partition does not exists. Failed to add logical partition.
Failed to add #1 partition: Invalid argument
```

This looked correct for years because gawk's hash order happens to match
insertion order for `/dev/sdaN` while N <= 9. Add a tenth partition and
`/dev/sda10` hashes to the front. There was never a correct version — only
inputs whose hash order flattered it. Every `partition_names` traversal is now
ordered by partition number; the `ordered_starts` walk is pinned to
`@ind_num_asc` because it accumulates `curr_start` and needs asort's index order
instead.

Because capture writes a resized table back to the *source* disk, this broke
capture as well as deploy, which is why the reporter never got an image at all.

Two more faults in the same engine, both deploy-side:

- **No room for the EBRs.** `fill_disk()` reserved `MIN_START` per logical in
  `original_fixed` but nothing ever spent it when assigning starts, so logicals
  were packed end to end and sfdisk hit `No free sectors available`.
- **The container was scaled like data.** An extended partition's extent is
  defined by its contents, but `fill_disk()` ran its captured size through the
  same proportional grow/shrink as a filesystem partition, walking its end past
  the end of the target disk on any grow-to-fit deploy. Its size is now derived
  after the logicals are placed, which also means it inherits the disk-end clamp
  applied to the last logical for free.

`check_overlap()`'s containment branch was guarded on `p_number > 4` — the
*container's* own number, and an extended partition is always a primary, so the
check has never executed once. It is now guarded on `new_part_number > 4`, the
partition being tested. With the fill engine corrected it cannot fire on a table
this code produces; its only job is catching the next regression here before it
reaches a disk (ADR-0003's reasoning).

## 2. The extended partition was captured, and restored, as content

Linux exposes an extended partition as a device covering only the ~1 KB EBR
window at the front of the container. `savePartition()` dispatched on `$fstype`
before testing the partition type — and an extended partition has no
filesystem, so `fsTypeSetting()` resolves it to `imager` and that arm matched
first. The `0x5|0xf` arm below it was unreachable. FOG captured the EBR window
as a `d<disk>p<part>.img`, and deploy wrote it back over the chain
`fillDiskWithPartitions` had just built, so every logical after the first ceased
to exist mid-restore:

```
 * Restoring EBR for (/dev/sda3).....................Done
 * Processing Partition: /dev/sda5 (5)
partclone.c,open_target,1818: open /dev/sda6 error(2)
```

Capture now tests for the container before the `$fstype` dispatch and writes
only the `.ebr` sidecar. Deploy's guard keys off the partition **type, not the
absence of a `.img`** — every image captured before this fix still carries that
stale file, and those are exactly the images that break, so a guard deferring to
the file would keep failing on the whole existing image library. **Existing
images therefore need no re-capture.**

## Validation

Verified against a FOG 1.6 server, not only in the harness: a 16 GiB MBR disk
with the reporter's shape (3 primaries including an LBA extended, plus 6
logicals) captured, then deployed onto a 24 GiB disk. All ten partitions came
back, every logical inside the container with its EBR gap intact, and all eight
payload sha256s matched the source byte for byte.

`tests/checks/mbr-extended.sh` adds 17 cases and 10 of them fail against the
pre-fix tree. Where a real sfdisk is on the host it also *applies* each computed
table to a sparse file, which is the only assertion proving sfdisk accepts the
layout rather than that the numbers look plausible — the bug was sfdisk
rejecting a table whose arithmetic was fine. The golden fixture is unchanged.

The lab disk was synthetic (`sfdisk` + `mke2fs -d` rather than installed by an
OS), so it exercises the geometry and the data path but not a bootloader in the
extended chain. Reasoning and limitations are recorded in
`docs/adr/0014-mbr-extended-partitions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
