### PR TITLE
Retry the kernel and buildroot downloads instead of losing the whole build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -193,7 +193,7 @@ function buildFilesystem() {
     if [[ ! -d fssource$arch ]]; then
         if [[ ! -f buildroot-$BUILDROOT_VERSION.tar.xz ]]; then
             dots "Downloading buildroot source package"
-            wget -q "$brURL" && echo "Done"
+            wget -q --tries=3 --waitretry=10 --read-timeout=60 "$brURL" && echo "Done"
             if [[ $? -ne 0 ]]; then
                 echo "Failed"
                 exit 1
@@ -360,7 +360,7 @@ function buildKernel() {
     [[ -d kernelsource$arch ]] && rm -rf "kernelsource$arch"
     if [[ ! -f linux-$KERNEL_VERSION.tar.xz ]]; then
         dots "Downloading kernel source"
-        wget -q "$kernelURL" && echo "Done"
+        wget -q --tries=3 --waitretry=10 --read-timeout=60 "$kernelURL" && echo "Done"
         if [[ $? -ne 0 ]]; then
             echo "Failed"
             exit 1


### PR DESCRIPTION
Today's experimental build ([run 32254827836](https://github.com/FOGProject/fos/actions/runs/32254827836)) failed after 34 minutes on:

```
Preparing kernel 6.18.38 on arm64 build:
 * Downloading kernel source...................................Failed
```

The x64 and x86 kernel jobs fetched **the same URL in the same run** and succeeded, so it was one transient CDN hiccup. A single `wget -q` with no retry turns that into a failed release: the `release` job is skipped, nothing is published, and every artefact that *did* build in that run is thrown away.

Both source downloads (kernel, buildroot) get `--tries=3 --waitretry=10 --read-timeout=60`.

- Three attempts ten seconds apart costs at most twenty seconds on a genuinely unreachable host, against a rebuild measured in tens of minutes.
- The read timeout matters as much as the retry: wget's default is *no* timeout, so a stalled connection hangs the job until the runner's own limit instead of failing fast enough to retry.

Both call sites, not just the one that broke today — identical shape, identical exposure.