### PR TITLE
Confirm the promotion by asking what /releases/latest resolves to

### DIFF
--- a/.github/workflows/promote_experimental_release.yml
+++ b/.github/workflows/promote_experimental_release.yml
@@ -183,12 +183,21 @@ jobs:
             --prerelease=false \
             --latest
 
+      # Asks what /releases/latest actually resolves to, rather than reading a
+      # field off the release. That is the thing the installer resolves, so it
+      # is the thing worth confirming -- and `gh release view` has no field for
+      # it: there is no isLatest, and asking for one exits 1 with a list of
+      # valid fields, which is how the first run of this workflow reported
+      # failure on a promotion that had entirely succeeded.
       - name: Confirm what landed
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ inputs.tag }}
         run: |
-          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
-            --json tagName,name,isPrerelease,isLatest \
-            -q '"tag=\(.tagName) name=\(.name) prerelease=\(.isPrerelease) latest=\(.isLatest)"' \
-            | tee -a "$GITHUB_STEP_SUMMARY"
+          landed=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" \
+            -q '"tag=\(.tag_name) name=\(.name) prerelease=\(.prerelease)"')
+          echo "$landed" | tee -a "$GITHUB_STEP_SUMMARY"
+          if ! grep -q "tag=$TAG " <<<"$landed "; then
+            echo "::error::$TAG was edited but /releases/latest still resolves elsewhere: $landed"
+            exit 1
+          fi


### PR DESCRIPTION
The first real run of #153 ([32266072854](https://github.com/FOGProject/fos/actions/runs/32266072854)) **reported failure on a promotion that had entirely succeeded** — `EXP_20260819-141018` was retitled `Latest from 2026-08-19`, un-prereleased and marked latest, and the run went red anyway.

Cause: `gh release view --json isLatest` is not a field. gh exits 1 and prints the list of valid fields, and that was the workflow's last step.

Asking the API what `/releases/latest` resolves to is both the fix and the better check — that URL is what the FOG installer downloads from, so it is the thing worth confirming. A release can be edited successfully and still not be the one that endpoint serves. The step now fails only if the tag it just promoted is not the tag that endpoint names.

Both the passing and the failing case were run against the live repo state before committing:

```
tag=EXP_20260819-141018 name=Latest from 2026-08-19 prerelease=false
check passes                      # the promoted tag
wrong-tag check correctly fails   # any other tag
```