### PR TITLE
Convert sector units for every sfdisk action, and leave last-lba alone

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/partition-funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/partition-funcs.sh
@@ -327,7 +327,8 @@ makeSwapSystem() {
     debugPause
 }
 # $1 is the partition device (e.g. /dev/sda1)
-# $2 is the new desired size in 1024 (1k) blocks
+# $2 is the new desired size in BYTES (funcs.sh passes the shrunk filesystem
+#    size; procsfdisk.awk divides it by the disk's logical sector size)
 # $3 is the image path (e.g. /net/dev/foo)
 resizeSfdiskPartition() {
     local part="$1"
@@ -410,7 +411,7 @@ fillSfdiskWithPartitions() {
 #	foo.sfdisk = sfdisk -d output
 #	resize = action
 #	/dev/sda1 = partition to modify
-#	100000 = 1024 byte blocks size to make it
+#	100000 = size in BYTES to make it
 #	output: new sfdisk -d like output
 #
 # processSfdisk foo.sfdisk move /dev/sda1 100000
@@ -449,27 +450,34 @@ processSfdisk() {
     [[ -z $target ]] && handleError "Device (disk or partition) not passed (${FUNCNAME[0]})\n   Args Passed: $*"
     [[ -z $size ]] && handleError "No desired size passed (${FUNCNAME[0]})\n   Args Passed: $*"
     local disk_size=$(blockdev --getsz ${disk})
-    # A whole-disk fill restores an image whose partition offsets/sizes were captured
-    # in the image's logical sector unit. Two awk inputs must track that unit or the
-    # fill math misbehaves on non-512 (e.g. 4Kn) targets:
-    #   diskSize    - blockdev --getsz always reports 512-byte units; convert it into
-    #                 the target's logical-sector unit, else every resizable partition
-    #                 inflates (~8x on 4Kn) and runs off the end of the disk.
-    #   SECTOR_SIZE - the fill engine uses this ONLY as a size-alignment quantum
-    #                 (p_size -= p_size % SECTOR_SIZE). 512 sectors = 256 KiB at
-    #                 512-byte sectors; feed that same 256 KiB granularity in the
-    #                 target's unit so a small resizable partition isn't rounded to 0
-    #                 (a 1 MiB bios_grub is 256 sectors on 4Kn; a 4096-sector quantum
-    #                 would zero it and corrupt the table).
-    # No-op on 512-byte-sector disks: getss=512 makes both identities
-    # (disk_size*512/512 = disk_size; 512*512/512 = 512).
-    if [[ $action == filldisk ]]; then
-        local logsectorsize=$(blockdev --getss ${disk} 2>/dev/null)
-        if [[ -n $logsectorsize && $logsectorsize -gt 0 ]]; then
-            disk_size=$(( disk_size * 512 / logsectorsize ))
-            sectorsize=$(( 512 * 512 / logsectorsize ))
-        fi
-    fi
+    # Every action here computes against a partition table whose offsets and sizes are
+    # expressed in the disk's LOGICAL sector unit, so three awk inputs have to track that
+    # unit or the arithmetic quietly means something else on a non-512 (e.g. 4Kn) disk:
+    #   diskSize            - blockdev --getsz always reports 512-byte units; convert it
+    #                         into the disk's logical-sector unit, else filldisk inflates
+    #                         every resizable partition (~8x on 4Kn) off the end of the
+    #                         disk, and resize's own bounds checks compare against a
+    #                         number 8x too large to ever catch anything.
+    #   SECTOR_SIZE         - the fill engine uses this ONLY as a size-alignment quantum
+    #                         (p_size -= p_size % SECTOR_SIZE). 512 sectors = 256 KiB at
+    #                         512-byte sectors; feed that same 256 KiB granularity in the
+    #                         disk's unit so a small resizable partition isn't rounded to 0
+    #                         (a 1 MiB bios_grub is 256 sectors on 4Kn; a 4096-sector
+    #                         quantum would zero it and corrupt the table).
+    #   LOGICAL_SECTOR_SIZE - the raw logical sector size, which is what the resize action
+    #                         divides its byte-count argument by to get a sector count.
+    #                         Deliberately NOT SECTOR_SIZE: overloading one variable with
+    #                         an alignment quantum and a unit divisor is what hid the 4Kn
+    #                         resize bug for years, because on a 512-byte disk the two
+    #                         values are equal. See ADR-0016.
+    # This whole block ran for filldisk only until ADR-0016, so resize got 512-byte units
+    # on a 4Kn disk and emitted a last-lba past the end of it.
+    # No-op on 512-byte-sector disks: getss=512 makes all three identities
+    # (disk_size*512/512 = disk_size; 512*512/512 = 512; the divisor is 512).
+    local logsectorsize=$(blockdev --getss ${disk} 2>/dev/null)
+    [[ -n $logsectorsize && $logsectorsize -gt 0 ]] || logsectorsize=512
+    disk_size=$(( disk_size * 512 / logsectorsize ))
+    sectorsize=$(( 512 * 512 / logsectorsize ))
     local minstart=$(awk -F'[ ,]+' '/start/{if ($4) print $4}' $data | sort -n | head -1)
     local chunksize=""
     getPartBlockSize "$disk" "chunksize"
@@ -485,6 +493,7 @@ processSfdisk() {
     #local awkArgs="-v SECTOR_SIZE=$chunksize -v CHUNK_SIZE=$chunksize -v MIN_START=$minstart"
     awkArgs="$awkArgs -v action=$action -v target=$target -v sizePos=$size"
     awkArgs="$awkArgs -v diskSize=$disk_size"
+    awkArgs="$awkArgs -v LOGICAL_SECTOR_SIZE=$logsectorsize"
     [[ -n $fixed ]] && awkArgs="$awkArgs -v fixedList=$fixed"
     # process with external awk script
     if [[ -r $data ]]; then
@@ -587,7 +596,7 @@ hasGPT() {
 # resizePartition function
 #
 # $1 is the partition device (e.g. /dev/sda1)
-# $2 is the new desired size in 1024 (1k) blocks
+# $2 is the new desired size in BYTES
 # $3 is the image path (e.g. /net/dev/foo)
 resizePartition() {
     local part="$1"

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/procsfdisk.awk
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/procsfdisk.awk
@@ -9,7 +9,14 @@
 #
 # Usage Passed in Variables:
 #
-# SECTOR_SIZE The default sector size. Currently set to 512
+# SECTOR_SIZE The size-alignment quantum, in sectors -- NOT the sector size,
+#             despite the name. 512 on a 512-byte-sector disk (= 256 KiB), 64 on
+#             a 4Kn one (the same 256 KiB). Only ever used as `x % SECTOR_SIZE`.
+# LOGICAL_SECTOR_SIZE
+#             The disk's logical sector size in bytes (512, 4096, ...). This is
+#             the unit the whole table is expressed in, and the divisor that turns
+#             resize's byte-count argument into a sector count. Distinct from
+#             SECTOR_SIZE on purpose: see ADR-0016. Defaults to 512.
 # CHUNK_SIZE  The default block size for the disk/partition being used. Typically 512
 # MIN_START   The minimum start position for the first partition. Typically 2048.
 # action      The action to perform with the script.
@@ -337,8 +344,14 @@ function resize_partition(partition_names, partitions, args, pName, new_start, n
         }
         # Set our p_start position to the current start.
         new_start = int(partitions[pName, "start"]);
-        # Ensure start postition is aligned properly.
-        new_size = int(sizePos) / int(SECTOR_SIZE);
+        # sizePos is a BYTE count -- funcs.sh passes the size it just shrank the
+        # filesystem to -- and this table is in logical sectors, so the divisor is
+        # the logical sector size. It is NOT SECTOR_SIZE, which is an alignment
+        # quantum that only equals the sector size on a 512-byte disk; dividing by
+        # it on a 4Kn disk produced a size 8x too large. Rounding is UP, because
+        # the filesystem is already sizePos bytes: a partition rounded down would
+        # be smaller than the filesystem inside it. See ADR-0016.
+        new_size = int((int(sizePos) + int(LOGICAL_SECTOR_SIZE) - 1) / int(LOGICAL_SECTOR_SIZE));
         # Check the overlap.
         overlap = check_overlap(partition_names, partitions, target, new_start, new_size);
         # If there was an issue in checking overlap, skip.
@@ -360,9 +373,16 @@ function resize_partition(partition_names, partitions, args, pName, new_start, n
         partitions[target, "start"] = new_start;
         partitions[target, "size"] = new_size;
     }
-    if (lastlba) {
-        lastlba = int(diskSize) - int(firstlba);
-    }
+    # last-lba is deliberately NOT recomputed here. It describes where the disk
+    # ends, sfdisk -d read it from the disk we are about to write back to, and
+    # shrinking one partition does not move the end of a disk. Recomputing it as
+    # diskSize - firstlba emitted a last-lba past the end of a 4Kn disk (diskSize
+    # arrived in 512-byte units) and made sfdisk refuse the whole table; on a
+    # 512-byte disk it silently reserved 1 MiB of tail that the true value
+    # (diskSize - 34 on GPT) does not, which fail-loud would now abort on for any
+    # image whose last partition reached into it. fill_disk()'s own assignment is
+    # a different case and stays: there we are building a table for a disk whose
+    # size we were told, and its clamp has to agree with what it emits. ADR-0016.
     return 0;
 }
 
@@ -742,6 +762,13 @@ BEGIN {
     # sizePos;
     # diskSize;
     # fixedList;
+    # LOGICAL_SECTOR_SIZE;
+    # processSfdisk always passes this; defaulted so the script stays runnable by
+    # hand, and so an older caller cannot turn the resize divisor into a division
+    # by zero.
+    if (!LOGICAL_SECTOR_SIZE) {
+        LOGICAL_SECTOR_SIZE = 512;
+    }
     label = "";
     unit = "";
     partitions[0] = "";

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,7 @@ tests/golden/run.sh print     # dump current output to stdout, no comparison
 
 tests/checks/sector-size.sh   # validateImageSectorSize() refusal/reformat behavior
 tests/checks/fill-engine.sh   # sfdisk fill engine: 4Kn rescaling, GPT clamp, abort-on-unusable-table
+tests/checks/resize-engine.sh # capture-time shrink: 4Kn units, last-lba passthrough, round-up (ADR-0016)
 tests/checks/mbr-extended.sh  # MBR extended/logical layouts: emission order, EBR gaps, container sizing
 tests/checks/wipe.sh          # wipeDisk() erase-primitive-per-device-class correctness
 tests/checks/lvm.sh           # per-LV LVM capture/deploy/resize paths
@@ -321,6 +322,23 @@ and add a new ADR for any similarly hard-to-reverse decision:
   server half does not exist** — FOG emits iPXE, not U-Boot `boot.scr`, so a Pi
   still cannot be imaged end to end. Guarded by
   `tests/checks/arm64-platform-config.sh`.
+- **0016 — sector units in the resize path.** `processSfdisk()` converted
+  `blockdev --getsz`'s 512-byte units into the disk's logical-sector unit for
+  `action=filldisk` only, so the capture-time shrink read a 4Kn disk as eight
+  times its real size; and `resize_partition()` divided its **byte** argument by
+  `SECTOR_SIZE`, which is an *alignment quantum*, not a sector size — the two
+  coincide only on 512-byte disks, which is why this survived for years. The raw
+  logical sector size now travels as its own `LOGICAL_SECTOR_SIZE`: **do not
+  merge it back into `SECTOR_SIZE`.** The conversion rounds **up**, because the
+  filesystem has already been shrunk to that byte count. Third invariant: a
+  capture-time shrink **never recomputes `last-lba`** — it describes where the
+  disk ends, `sfdisk -d` read it from that same disk, and shrinking a partition
+  does not move it; `fill_disk()`'s identical-looking assignment is a different
+  case and stays. The trap this ADR exists for: none of this was a regression.
+  The same broken table was computed on every 4Kn capture for years, and
+  ADR-0003's fail-loud apply is the only reason anyone found out — so reverting
+  to an older init re-hides it rather than fixing it. Guarded by
+  `tests/checks/resize-engine.sh`.
 
 General conventions to preserve when editing `funcs.sh`/`partition-funcs.sh`:
 

--- a/docs/adr/0016-sector-units-in-the-resize-path.md
+++ b/docs/adr/0016-sector-units-in-the-resize-path.md
@@ -1,5 +1,7 @@
 # Sector units belong to every sfdisk action, and last-lba belongs to the disk
 
+Reported as GH-159.
+
 Capturing a resizable image from a 4Kn disk aborted with sfdisk's `Last LBA
 specified by script is out of range`, reported as
 `sfdisk failed to apply the partition table to /dev/vda (applySfdiskPartitions)`.

--- a/docs/adr/0016-sector-units-in-the-resize-path.md
+++ b/docs/adr/0016-sector-units-in-the-resize-path.md
@@ -1,0 +1,117 @@
+# Sector units belong to every sfdisk action, and last-lba belongs to the disk
+
+Capturing a resizable image from a 4Kn disk aborted with sfdisk's `Last LBA
+specified by script is out of range`, reported as
+`sfdisk failed to apply the partition table to /dev/vda (applySfdiskPartitions)`.
+Two unit errors in the capture-time shrink caused it, and a third decision — that
+a shrink may rewrite the disk's own `last-lba` — is what turned them into a
+refused table rather than a slightly wrong one. All three are settled here.
+
+The important part of the diagnosis: **this was not a regression.** The same
+broken table was computed on every 4Kn capture for years. Until ADR-0003 made
+`applySfdiskPartitions()` fatal, sfdisk rejected it into a `majorDebugEcho` and
+capture carried on with the partition table untouched — so a 4Kn "resizable"
+capture silently produced an unshrunk table and nobody knew. Reverting to an
+older init does not fix this; it re-hides it.
+
+## The three decisions
+
+### 1. `diskSize` is rescaled for every action, not just `filldisk`
+
+`processSfdisk()` converts `blockdev --getsz` (always 512-byte units) into the
+disk's logical-sector unit, because that is the unit the partition table it is
+about to rewrite is expressed in. That conversion was introduced for the deploy
+path and guarded with `if [[ $action == filldisk ]]`, which left `resize` — the
+capture path — reading a 64 GiB 4Kn disk as 134217728 sectors instead of
+16777216.
+
+The guard is gone. Every action gets the rescale, because every action compares
+against `diskSize`: `check_overlap()` uses it as the bound for "does this
+partition fit on the disk", and with a value eight times too large that check
+cannot fail no matter how wrong the layout is. The rescale is an exact no-op on
+512-byte-sector disks (`disk_size * 512 / 512`), so this is not a behaviour
+change there.
+
+### 2. `SECTOR_SIZE` and `LOGICAL_SECTOR_SIZE` are different numbers
+
+`SECTOR_SIZE` is not the sector size, despite the name. `fill_disk()` uses it
+only as a size-alignment quantum — `p_size -= p_size % SECTOR_SIZE` — and it is
+deliberately scaled to hold 256 KiB of granularity in whatever unit the disk
+uses: 512 sectors on a 512-byte disk, 64 on a 4Kn one. ADR-0002 explains why:
+a 1 MiB `bios_grub` is 256 sectors on 4Kn, and a 4096-sector quantum rounds it
+to zero and corrupts the table.
+
+`resize_partition()` was using that same variable as a **unit divisor**, to turn
+the byte count it is passed into a sector count. On a 512-byte disk the two
+meanings coincide, which is exactly why the bug survived: `sizePos / 512` is
+right for a 512-byte disk and eight times too large for a 4Kn one.
+
+So the raw logical sector size now travels as its own awk variable,
+`LOGICAL_SECTOR_SIZE`, and `SECTOR_SIZE` keeps the one meaning it is documented
+to have. **Do not merge them again.** One variable that means an alignment
+quantum in one function and a unit divisor in another is a bug that only shows
+up on hardware most people do not have.
+
+The conversion **rounds up**:
+`(sizePos + LOGICAL_SECTOR_SIZE - 1) / LOGICAL_SECTOR_SIZE`. By the time the
+partition is resized the filesystem inside it has already been shrunk to
+`sizePos` bytes, so a partition rounded *down* is smaller than its own contents.
+The cost of rounding up is at most one sector. Note this also changes 512-byte
+disks for a request that is not a multiple of 512 — `extfs` reaches here with
+`size + percentage`, which is under no obligation to be — and by one sector in
+the safe direction.
+
+### 3. A capture-time shrink never recomputes `last-lba`
+
+`resize_partition()` used to overwrite the dumped `last-lba` with
+`diskSize - firstlba`. That is wrong in principle regardless of units: `last-lba`
+describes where the *disk* ends, `sfdisk -d` read it from the very disk the table
+is about to be written back to, and shrinking one partition does not move the end
+of a disk. It is now passed through untouched.
+
+Both failure modes it caused are worth recording:
+
+- With `diskSize` in 512-byte units on a 4Kn disk it named a last-usable LBA
+  eight times past the end of the disk, and sfdisk refused the whole script at
+  the header stage — the reported bug.
+- Even with correct units it was still wrong on a 512-byte GPT disk:
+  `diskSize - 2048` against a true last-usable of `diskSize - 34` silently
+  reserved 1 MiB of tail. That never surfaced only because the apply used to fail
+  silently; post-ADR-0003 it would abort a capture whose last partition reached
+  into that megabyte.
+
+`fill_disk()`'s own `lastlba = diskSize - firstlba` is a **different case and
+stays.** There we are computing a table for a disk whose size we were told rather
+than one we read a table from, and the value has to agree with the `disk_end`
+clamp in the same function (see the comment at that clamp). The two assignments
+look identical and are not.
+
+## Consequences
+
+- A 4Kn resizable capture now actually shrinks the partition, for the first time.
+  That means the deploy-side fill for 4Kn — correct since ADR-0002 but almost
+  certainly never exercised on real 4Kn hardware — starts being reached in
+  earnest. A 4Kn image is worth round-tripping (capture *and* deploy) before it
+  is trusted.
+- `tests/checks/resize-engine.sh` is the guard, and is the capture-side sibling
+  of `tests/checks/fill-engine.sh`. It pins the passthrough, the divisor, the
+  rounding direction, and that a valid 4Kn shrink reaches the sfdisk write.
+- `tests/checks/mbr-extended.sh`'s resize case had encoded the old flooring
+  behaviour (`10000000 / 512`) and now expects the rounded-up value. It is the
+  only in-tree assertion the rounding change moved.
+
+## Alternatives rejected
+
+**Revert ADR-0003's fail-loud apply.** It would restore the observed "working"
+March behaviour, and that behaviour is a 4Kn capture that quietly does not
+shrink. The refusal was the only reason anyone found out.
+
+**Reuse `SECTOR_SIZE` for the divisor by moving the existing rescale out of the
+`filldisk` guard.** The smallest diff, and it works — because on the disks where
+the two meanings differ the rescaled quantum (64) happens to be wrong in a
+different way than 512 is. Keeping one name for two quantities is what hid this;
+it would hide the next one too.
+
+**Fix the units and keep recomputing `last-lba`.** Fixes the reported abort and
+leaves the 512-byte tail reservation in place as a latent fail-loud trigger on
+any barely-fitting image.

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,6 +45,17 @@ tests/checks/fill-engine.sh   # the whole-disk fill engine (processSfdisk +
                               # alive, the GPT backup-header clamp holds, and an
                               # unusable computed table aborts instead of being
                               # written
+tests/checks/resize-engine.sh # the capture-time shrink (processSfdisk +
+                              # resizeSfdiskPartition + resize_partition in the
+                              # awk), the deploy engine's sibling: the disk's own
+                              # last-lba is passed through rather than recomputed,
+                              # the byte-count argument is divided by the LOGICAL
+                              # sector size (not the alignment quantum) so a 4Kn
+                              # shrink asks for an eighth as many sectors rather
+                              # than eight times too many, that division rounds up
+                              # so a partition is never smaller than the
+                              # filesystem already shrunk into it, and a valid 4Kn
+                              # shrink reaches the sfdisk write (ADR-0016)
 tests/checks/mbr-extended.sh  # MBR tables carrying an extended partition with
                               # logicals inside it (issue #150): the emitted
                               # table is ordered by partition number so sfdisk

--- a/tests/checks/mbr-extended.sh
+++ b/tests/checks/mbr-extended.sh
@@ -159,11 +159,16 @@ fi
 apply_for_real "resize output applies to a real disk" "$DISK80"
 
 # 2. The resize itself still lands on the requested partition, and only on it.
-if [[ $(psize /dev/sda6) -eq $(( 10000000 / 512 )) && $(psize /dev/sda5) -eq 21116928 \
+#    10000000 bytes is not a whole number of 512-byte sectors, and the byte ->
+#    sector conversion rounds UP (ADR-0016): the filesystem has already been
+#    shrunk to that byte size, so flooring would leave the partition smaller
+#    than the filesystem inside it. Hence (bytes + 511) / 512, not bytes / 512.
+WANTSDA6=$(( (10000000 + 511) / 512 ))
+if [[ $(psize /dev/sda6) -eq $WANTSDA6 && $(psize /dev/sda5) -eq 21116928 \
       && $(psize /dev/sda10) -eq 49217536 ]]; then
     pass "resize shrinks only the target logical partition"
 else
-    fail "resize target" "sda6=$(psize /dev/sda6) sda5=$(psize /dev/sda5) sda10=$(psize /dev/sda10)"
+    fail "resize target" "sda6=$(psize /dev/sda6) (want $WANTSDA6) sda5=$(psize /dev/sda5) sda10=$(psize /dev/sda10)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/checks/resize-engine.sh
+++ b/tests/checks/resize-engine.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+#
+# Assertion harness for the capture-time partition shrink: processSfdisk() +
+# resizeSfdiskPartition() in partition-funcs.sh and resize_partition() in
+# procsfdisk.awk.
+#
+#   tests/checks/resize-engine.sh      # run all cases, exit non-zero on any failure
+#
+# tests/checks/fill-engine.sh covers the DEPLOY side (action=filldisk). Nothing
+# covered the CAPTURE side until ADR-0016, and that is where the 4Kn bug lived:
+# processSfdisk rescaled its sector units for filldisk only, so on a 4Kn disk the
+# resize action received diskSize in 512-byte units and divided a byte count by an
+# alignment quantum. The table it emitted named a last-lba eight times past the end
+# of the disk, sfdisk refused it, and until ADR-0003 made the apply fail loud that
+# refusal was swallowed into a debug line -- the shrink simply never happened.
+#
+# What this harness locks:
+#
+#   1. last-lba is passed through, not recomputed. It describes where the disk
+#      ends; shrinking one partition does not move that. The emitted value must
+#      equal the dump's, and must lie inside the disk in the TABLE's own unit --
+#      the assertion the original bug would have failed.
+#   2. The byte-count argument is divided by the LOGICAL sector size, so a 4Kn
+#      shrink asks for an eighth of the sectors a 512-byte one would, not eight
+#      times too many.
+#   3. That division rounds UP. The filesystem has already been shrunk to sizePos
+#      bytes, so a partition rounded down is smaller than the filesystem in it.
+#   4. A valid 4Kn resize reaches the sfdisk write instead of aborting, and a
+#      refused write still aborts.
+#
+# Mechanism mirrors tests/checks/fill-engine.sh: a sandbox copy of the library with
+# the hardcoded awk path rewritten to the in-tree script, blockdev/flock/sfdisk
+# PATH-shadowed with deterministic stubs, and the funcs.sh helpers the entry points
+# call overridden. handleError is overridden AFTER sourcing so an abort is
+# observable (it still exits the case subshell, as the real one exits init).
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_LIB="$HERE/../../Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib"
+
+[[ -f $REPO_LIB/partition-funcs.sh ]] || { echo "ERROR: cannot find partition-funcs.sh under $REPO_LIB" >&2; exit 2; }
+[[ -f $REPO_LIB/procsfdisk.awk ]] || { echo "ERROR: cannot find procsfdisk.awk under $REPO_LIB" >&2; exit 2; }
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+REALAWK="$REPO_LIB/procsfdisk.awk"
+sed -e "s#/usr/share/fog/lib/procsfdisk\.awk#awk -f $REALAWK#g" \
+    "$REPO_LIB/partition-funcs.sh" > "$SANDBOX/partition-funcs.sh"
+
+STUBBIN="$SANDBOX/bin"
+mkdir -p "$STUBBIN"
+
+# blockdev: --getsz is always in 512-byte units (that is the whole trap this
+# harness exists for), --getss the logical sector size.
+cat > "$STUBBIN/blockdev" <<'STUB'
+#!/bin/bash
+case "$1" in
+    --getsz)   printf '%s\n' "$FAKE_GETSZ" ;;
+    --getss)   printf '%s\n' "$FAKE_GETSS" ;;
+    --getpbsz) printf '%s\n' "$FAKE_GETPBSZ" ;;
+esac
+exit 0
+STUB
+chmod +x "$STUBBIN/blockdev"
+
+cat > "$STUBBIN/flock" <<'STUB'
+#!/bin/bash
+shift
+exec "$@"
+STUB
+chmod +x "$STUBBIN/flock"
+
+# sfdisk double: keep the table it was handed so a case can assert on what would
+# really have been written, and exit $FAKE_SFDISK_RC.
+cat > "$STUBBIN/sfdisk" <<'STUB'
+#!/bin/bash
+cat > "$SANDBOX/applied" 2>/dev/null
+exit ${FAKE_SFDISK_RC:-0}
+STUB
+chmod +x "$STUBBIN/sfdisk"
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; [[ -n $2 ]] && echo "      $2"; FAIL=$((FAIL + 1)); }
+
+# --- parse helpers over $OUT (the emitted "sfdisk -d" table) ---
+psize()    { printf '%s\n' "$OUT" | sed -n "s#^$1 : .*size= *\([0-9]\{1,\}\).*#\1#p" | head -1; }
+pstart()   { printf '%s\n' "$OUT" | sed -n "s#^$1 : start= *\([0-9]\{1,\}\).*#\1#p" | head -1; }
+plastlba() { printf '%s\n' "$OUT" | sed -n 's#^last-lba: *\([0-9]\{1,\}\).*#\1#p' | head -1; }
+
+# run_resize <dumpfile> <getsz> <getss> <part> <bytes> -- drive processSfdisk's
+# resize action over a disk with the given geometry. Leaves the emitted table in
+# $OUT and processSfdisk's exit in $RC.
+run_resize() {
+    local dump="$1" getsz="$2" getss="$3" part="$4" bytes="$5"
+    OUT="$(
+        set +u
+        export PATH="$STUBBIN:$PATH"
+        export FAKE_GETSZ="$getsz" FAKE_GETSS="$getss" FAKE_GETPBSZ="$getss"
+        . "$SANDBOX/partition-funcs.sh"
+        handleError() { echo "ABORT: $*"; exit 1; }
+        handleWarning() { :; }
+        getPartBlockSize() { printf -v "$2" '%s' "$FAKE_GETPBSZ"; }
+        runPartprobe() { :; }
+        majorDebugEcho() { :; }; majorDebugPause() { :; }
+        ismajordebug=0
+        disk="/dev/vda"                        # processSfdisk reads the global $disk
+        processSfdisk "$dump" resize "$part" "$bytes"
+    )"
+    RC=$?
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures. Both describe the same 64 GiB disk, one as 512-byte sectors and one
+# as 4Kn -- the geometry from the bug report.
+DISK4K=16777216                                # 64 GiB in 4096-byte units
+GETSZ4K=$(( DISK4K * 8 ))                      # what blockdev --getsz reports
+LAST4K=$(( DISK4K - 6 ))
+cat > "$SANDBOX/d.4k" <<EOF
+label: gpt
+label-id: EE9A77DD-0E9D-4825-BBA0-702095906226
+device: /dev/vda
+unit: sectors
+first-lba: 6
+last-lba: $LAST4K
+sector-size: 4096
+
+/dev/vda1 : start=         256, size=      262144, type=DE94BBA4-06D1-4D40-A16A-BFD50179D6AC
+/dev/vda2 : start=      262400, size=      262144, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+/dev/vda3 : start=      524544, size=      262144, type=E3C9E316-0B5C-4DB8-817D-F92DF00215AE
+/dev/vda4 : start=      786688, size=    15990272, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
+EOF
+
+DISK512=134217728                              # the same 64 GiB in 512-byte units
+LAST512=$(( DISK512 - 34 ))
+cat > "$SANDBOX/d.512" <<EOF
+label: gpt
+label-id: EE9A77DD-0E9D-4825-BBA0-702095906227
+device: /dev/vda
+unit: sectors
+first-lba: 34
+last-lba: $LAST512
+sector-size: 512
+
+/dev/vda1 : start=        2048, size=     2097152, type=DE94BBA4-06D1-4D40-A16A-BFD50179D6AC
+/dev/vda2 : start=     2099200, size=     2097152, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+/dev/vda3 : start=     4196352, size=     2097152, type=E3C9E316-0B5C-4DB8-817D-F92DF00215AE
+/dev/vda4 : start=     6293504, size=   127922176, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
+EOF
+
+# ---------------------------------------------------------------------------
+# 1. 4Kn: the emitted last-lba is the dump's, and lies inside the disk measured
+#    in the table's own unit. Recomputing it as diskSize - firstlba with diskSize
+#    in 512-byte units produced 134217722 for this disk, which is what sfdisk
+#    rejected with "Last LBA specified by script is out of range".
+BYTES30G=32212254720                           # 30 GiB, an exact multiple of 4096
+run_resize "$SANDBOX/d.4k" "$GETSZ4K" 4096 /dev/vda4 "$BYTES30G"
+got=$(plastlba)
+if [[ $RC -eq 0 && $got == "$LAST4K" && $got -le $DISK4K ]]; then
+    pass "4Kn resize: last-lba passed through ($got), inside the disk ($DISK4K)"
+else
+    fail "4Kn resize last-lba" "rc=$RC last-lba=$got expected=$LAST4K diskSize=$DISK4K
+$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. 4Kn: the byte count is divided by the LOGICAL sector size. Dividing by
+#    SECTOR_SIZE (512, or the 64-sector alignment quantum) gives eight or 512
+#    times this.
+WANT=$(( BYTES30G / 4096 ))
+got=$(psize /dev/vda4)
+if [[ $got == "$WANT" ]]; then
+    pass "4Kn resize: size $got sectors == $BYTES30G bytes / 4096"
+else
+    fail "4Kn resize size" "got $got, expected $WANT (eight times would be $(( WANT * 8 )))
+$OUT"
+fi
+
+# The shrunk partition has to still fit inside the disk it was cut from -- the
+# end-to-end invariant that both of the above bugs broke.
+end=$(( $(pstart /dev/vda4) + got ))
+if [[ $end -le $LAST4K ]]; then
+    pass "4Kn resize: vda4 ends at $end, within last-usable $LAST4K"
+else
+    fail "4Kn resize fit" "vda4 ends at $end, past last-usable $LAST4K"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. 4Kn: a byte count that is not a whole number of sectors rounds UP. ext
+#    filesystems reach here with sizeextresize = size + percentage, which is
+#    under no obligation to land on a sector boundary; rounding down would leave
+#    the partition smaller than the filesystem already shrunk into it.
+BYTESODD=$(( BYTES30G + 1 ))
+run_resize "$SANDBOX/d.4k" "$GETSZ4K" 4096 /dev/vda4 "$BYTESODD"
+got=$(psize /dev/vda4)
+if [[ $got == "$(( WANT + 1 ))" && $(( got * 4096 )) -ge $BYTESODD ]]; then
+    pass "4Kn resize: $BYTESODD bytes rounded up to $got sectors ($(( got * 4096 )) bytes)"
+else
+    fail "4Kn resize rounding" "got $got for $BYTESODD bytes; want $(( WANT + 1 )) and size*4096 >= bytes
+$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. 512n keeps the divisor it always effectively had -- the sector size -- and
+#    gains the same last-lba passthrough. Before ADR-0016 this emitted
+#    diskSize - 34, which on this disk is 2014 sectors short of the truth:
+#    silently reserved tail that a barely-fitting image could need.
+run_resize "$SANDBOX/d.512" "$DISK512" 512 /dev/vda4 "$BYTES30G"
+got=$(psize /dev/vda4)
+gotlast=$(plastlba)
+if [[ $RC -eq 0 && $got == "$(( BYTES30G / 512 ))" && $gotlast == "$LAST512" ]]; then
+    pass "512n resize: size $got sectors, last-lba $gotlast passed through"
+else
+    fail "512n resize" "rc=$RC size=$got (want $(( BYTES30G / 512 ))) last-lba=$gotlast (want $LAST512)
+$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. End to end through resizeSfdiskPartition: a valid 4Kn shrink must reach the
+#    sfdisk write rather than abort, and what reaches sfdisk must be the table
+#    with the in-range last-lba. This is the case the bug report failed on.
+# resize_case <name> <dump> <getsz> <getss> <part> <bytes> <abort|noabort> <yes|no>
+# The last argument is whether the sfdisk write should have been ATTEMPTED. It is
+# not implied by the abort expectation: a bad layout aborts before sfdisk is ever
+# run, while a refused write aborts precisely because it was.
+resize_case() {
+    local name="$1" dump="$2" getsz="$3" getss="$4" part="$5" bytes="$6" expect="$7" expect_applied="$8"
+    rm -f "$SANDBOX/applied"
+    local out got
+    out="$(
+        set +u
+        export PATH="$STUBBIN:$PATH" SANDBOX="$SANDBOX"
+        export FAKE_GETSZ="$getsz" FAKE_GETSS="$getss" FAKE_GETPBSZ="$getss"
+        . "$SANDBOX/partition-funcs.sh"
+        handleError() { echo "ABORT: $*"; exit 1; }
+        handleWarning() { :; }
+        getPartBlockSize() { printf -v "$2" '%s' "$FAKE_GETPBSZ"; }
+        getDiskFromPartition() { disk="/dev/vda"; }
+        # Stand in for reading the table off the disk: hand back the fixture.
+        RESIZE_DUMP="$dump"
+        saveSfdiskPartitions() { cp "$RESIZE_DUMP" "$2"; }
+        runPartprobe() { :; }
+        majorDebugEcho() { :; }; majorDebugPause() { :; }
+        ismajordebug=0
+        resizeSfdiskPartition "$part" "$bytes" "/images/dev/stub"
+        echo "RETURNED"
+    )"
+    [[ $out == *"ABORT:"* ]] && got="abort" || got="noabort"
+    local applied="no"; [[ -f "$SANDBOX/applied" ]] && applied="yes"
+    if [[ $got != "$expect" ]]; then
+        fail "$name" "expected $expect, got $got applied=$applied: $(printf '%s' "$out" | tr '\n' '|')"
+        return
+    fi
+    if [[ $applied != "$expect_applied" ]]; then
+        fail "$name" "expected the sfdisk write attempted=$expect_applied, got $applied"
+        return
+    fi
+    pass "$name (expected $expect, write attempted=$applied)"
+}
+
+resize_case "resizeSfdiskPartition applies a 4Kn shrink" \
+    "$SANDBOX/d.4k" "$GETSZ4K" 4096 /dev/vda4 "$BYTES30G" noabort yes
+
+# What sfdisk was handed must name a last-lba the disk actually has; a table
+# sfdisk would reject is not a table this harness should call applied.
+appliedlast=$(sed -n 's#^last-lba: *\([0-9]\{1,\}\).*#\1#p' "$SANDBOX/applied" 2>/dev/null | head -1)
+if [[ -n $appliedlast && $appliedlast -le $DISK4K ]]; then
+    pass "4Kn shrink: table handed to sfdisk names last-lba $appliedlast (<= $DISK4K)"
+else
+    fail "4Kn shrink applied table" "last-lba in written table: '${appliedlast:-none}' vs disk $DISK4K"
+fi
+
+# 6. A failing sfdisk write still aborts (ADR-0003) -- the behaviour that turned
+#    this silent no-op into a visible failure in the first place.
+FAKE_SFDISK_RC=1 resize_case "resizeSfdiskPartition aborts when sfdisk refuses the table" \
+    "$SANDBOX/d.4k" "$GETSZ4K" 4096 /dev/vda4 "$BYTES30G" abort yes
+
+echo "----"
+echo "$PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
Fixes #159.

Three faults in the capture-time partition shrink, all in the `resize` action:

- `processSfdisk()` converted `blockdev --getsz`'s 512-byte units into the
  disk's logical-sector unit **only for `filldisk`**, so resize read a 64 GiB
  4Kn disk as 134217728 sectors instead of 16777216. The guard is gone — every
  action compares against `diskSize`, and `check_overlap()` cannot catch
  anything with a bound eight times too large.
- `resize_partition()` divided its **byte-count** argument by `SECTOR_SIZE`,
  which is an alignment quantum, not a sector size. The two coincide on a
  512-byte disk, which is why this survived. The raw logical sector size now
  travels as its own `LOGICAL_SECTOR_SIZE`, and the conversion rounds **up** —
  the filesystem has already been shrunk to that byte count, so flooring would
  leave the partition smaller than its contents.
- `resize_partition()` overwrote the `last-lba` that `sfdisk -d` had just read
  off the disk. It is now passed through. `fill_disk()`'s identical-looking
  assignment is a different case and is untouched.

**Not a regression.** The same table was computed on every 4Kn capture for
years; until ADR-0003 made the apply fatal, sfdisk's refusal went to a
`majorDebugEcho` and capture continued with the partition table untouched — so a
4Kn "resizable" capture silently never shrank anything.

Adds `tests/checks/resize-engine.sh` (the capture-side sibling of
`fill-engine.sh`, 8 cases) and ADR-0016. `mbr-extended.sh`'s resize case had
encoded the old flooring behaviour and now expects the rounded-up value; it is
the only in-tree assertion the rounding change moved.

## Testing

`resize-engine.sh` 8/8; `fill-engine.sh` 9/9, `mbr-extended.sh` 13/13 and
`lvm.sh` 121/121 unchanged from master. `sector-size.sh` and `golden` have one
pre-existing environment failure each on this host, identical on master.

**Not yet hardware-tested.** A 4Kn capture *and* deploy round trip is still
outstanding — worth noting that this change means the deploy-side 4Kn fill
starts being exercised in earnest for the first time.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S67FaXehexRLqnbsa5Jwmk
