### PR TITLE
Tell mount it is mounting NFS

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog
@@ -13,7 +13,8 @@ fi
 dots "Running post init scripts"
 [[ ! -d /imagesinit ]] && mkdir /imagesinit >/dev/null 2>&1
 umount /imagesinit >/dev/null 2>&1
-mount -o nolock,proto=tcp,rsize=32768,wsize=32768,intr,noatime "$storage" /imagesinit >/tmp/mount-output 2>&1
+# -t nfs is load-bearing, see the comment in fog.mount.
+mount -t nfs -o nolock,proto=tcp,rsize=32768,wsize=32768,intr,noatime "$storage" /imagesinit >/tmp/mount-output 2>&1
 if [[ $? -eq 0 ]]; then
     if [[ -f /imagesinit/.mntcheck ]]; then
         if [[ -f /imagesinit/postinitscripts/fog.postinit ]]; then

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.av
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.av
@@ -12,7 +12,8 @@ sysuuid=$(dmidecode -s system-uuid)
 sysuuid=${sysuuid,,}
 dots "Mounting Clamav"
 [[ ! -d /opt/fog/clamav ]] && mkdir -p /opt/fog/clamav >/dev/null 2>&1
-mount -o nolock,proto=tcp,rsize=32768,wsize=32768,intr,noatime $clamav /opt/fog/clamav >/tmp/mount-output 2>&1
+# -t nfs is load-bearing, see the comment in fog.mount.
+mount -t nfs -o nolock,proto=tcp,rsize=32768,wsize=32768,intr,noatime $clamav /opt/fog/clamav >/tmp/mount-output 2>&1
 if [[ ! $? -eq 0 ]]; then
     echo "Failed"
     debugPause

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.mount
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.mount
@@ -12,12 +12,18 @@ if [[ ! -d /images ]]; then
     fi
 fi
 umount /images >/dev/null 2>&1
+# The filesystem type is not optional here. busybox mount only infers NFS when
+# the source parses as host:/path; for anything else it walks every block-backed
+# filesystem in /proc/filesystems and tries each one, and every one of them
+# rejects 'nolock' as an unknown parameter. A malformed or empty storage= then
+# reports a cascade of unrelated local-filesystem errors instead of one NFS
+# failure, which is what made forums topic 18229 so hard to read.
 case $type in
     up)
-        mount -o nolock,proto=tcp,rsize=32768,wsize=32768,intr,noatime "$storage" /images >/tmp/mount-output 2>&1
+        mount -t nfs -o nolock,proto=tcp,rsize=32768,wsize=32768,intr,noatime "$storage" /images >/tmp/mount-output 2>&1
         ;;
     down)
-        mount -o nolock,proto=tcp,rsize=32768,intr,noatime "$storage" /images >/tmp/mount-output 2>&1
+        mount -t nfs -o nolock,proto=tcp,rsize=32768,intr,noatime "$storage" /images >/tmp/mount-output 2>&1
         ;;
 esac
 case $? in

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.photorec
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.photorec
@@ -18,7 +18,8 @@ fi
 echo "Done"
 debugPause
 dots "Mounting File System"
-mount -o nolock $storage /images >/tmp/mount-output 2>&1
+# -t nfs is load-bearing, see the comment in fog.mount.
+mount -t nfs -o nolock $storage /images >/tmp/mount-output 2>&1
 case $? in
     0)
         echo "Done"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,8 @@ tests/checks/pcie-aspm-config.sh    # kernel configs can control PCIe ASPM (ADR-
 tests/checks/initrd-format.sh       # each arch's kernel can unpack the init build.sh ships
 tests/checks/arm64-platform-config.sh  # arm64 kernel describes a real ARM platform (ADR-0015)
 
+tests/checks/nfs-mount-type.sh       # FOS's NFS mounts name -t nfs instead of relying on busybox inference
+
 tests/checks/package-mirrors.sh     # build.sh's package mirror fallback and hash enforcement
 ```
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -121,6 +121,17 @@ tests/checks/arm64-platform-config.sh
                               # ACPI, PCI_HOST_GENERIC and PL011 for non-Pi
                               # arm64. Also that build.sh builds dtbs.
                               # See ADR-0015
+tests/checks/nfs-mount-type.sh
+                              # every FOS mount carrying the NFS-only option
+                              # list also names -t nfs. busybox mount infers
+                              # NFS from the SOURCE ("host:/path"), not from
+                              # the options, and the init ships no mount.nfs
+                              # helper -- so an empty or malformed storage=
+                              # silently falls through to a walk of every
+                              # block-backed filesystem in /proc/filesystems,
+                              # each one rejecting 'nolock'. The console then
+                              # blames ext2/ext4/vfat/f2fs for a bad NFS path.
+                              # See forums topic 18229
 tests/checks/package-mirrors.sh
                               # build.sh's package-mirror seeding: resolves each
                               # package's version/source/site out of its own .mk

--- a/tests/checks/nfs-mount-type.sh
+++ b/tests/checks/nfs-mount-type.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Assertion harness for the explicit filesystem type on FOS's NFS mounts.
+#
+#   tests/checks/nfs-mount-type.sh
+#
+# Why this exists. FOS mounts the storage node with a hardcoded NFS option
+# list (nolock,proto=tcp,rsize=...,intr,noatime) and, until now, no -t. That
+# worked only because busybox mount infers NFS on its own -- and it does so
+# from the SOURCE STRING, not from the options: singlemount() in
+# util-linux/mount.c takes the NFS branch only when the source contains a ':'
+# whose first '/' comes after it. FOS's init ships no mount.nfs helper and
+# busybox is built without FEATURE_MOUNT_NFS, so there is no second chance.
+#
+# When storage= is empty or malformed the inference silently fails, and
+# busybox falls through to get_block_backed_filesystems() -- it walks every
+# block-backed entry in /proc/filesystems and tries each one in turn. Each
+# rejects 'nolock' as an unknown parameter, so the console fills with errors
+# naming local filesystems that were never involved:
+#
+#     ext3: Unknown parameter 'nolock'
+#     ext2: Unknown parameter 'nolock'
+#     ...
+#
+# That is what a Raspberry Pi 4 reporter saw in forums topic 18229, and it
+# sent the diagnosis toward the mount options for a day. With -t nfs present
+# mp->mnt_type is set, the walk is skipped entirely, and a bad storage= gets
+# one NFS error naming the actual source.
+#
+# The check is a grep because the invariant is textual and the failure is a
+# console message rather than a return code -- there is nothing to execute
+# that would reproduce it off-target. It anchors the whole call site rather
+# than just the flag, so a rewritten mount line is a visible failure.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$HERE/../../Buildroot/board/FOG/FOS/rootfs_overlay/bin"
+
+fails=0
+checked=0
+
+# Any mount carrying NFS-only options is an NFS mount and must say so.
+while IFS=: read -r file line text; do
+    checked=$((checked + 1))
+    if [[ $text != *"mount -t nfs "* ]]; then
+        echo "FAIL [$(basename "$file"):$line] NFS mount without an explicit -t nfs"
+        echo "       $(echo "$text" | sed 's/^[[:space:]]*//')"
+        fails=$((fails + 1))
+    else
+        echo "  checked $(basename "$file"):$line"
+    fi
+done < <(grep -rn '^[[:space:]]*mount .*nolock' "$BIN")
+
+if [[ $checked -eq 0 ]]; then
+    echo "FAIL: found no nolock mounts at all -- has the storage mount moved?"
+    exit 1
+fi
+
+echo
+if [[ $fails -eq 0 ]]; then
+    echo "PASS: $checked NFS mount(s) name their filesystem type"
+    exit 0
+fi
+echo "FAILED: $fails of $checked NFS mount(s) rely on busybox inferring the type"
+exit 1


### PR DESCRIPTION
## What

Adds `-t nfs` to the five FOS mounts that carry the NFS-only option list, plus a check that pins it.

## Why

FOS mounts the storage node with `nolock,proto=tcp,rsize=...,intr,noatime` and never named the filesystem type. That worked only because busybox mount infers NFS on its own — and it does so from the **source string**, not the options. `singlemount()` in `util-linux/mount.c` takes the NFS branch only when the source contains a `:` whose first `/` comes after it. FOS's init ships no `mount.nfs` helper, and busybox is built without `FEATURE_MOUNT_NFS` (verified: no NFS symbols in either the x64 or arm64 binary), so there is no fallback.

When `storage=` is empty or malformed, the inference silently fails and busybox falls through to `get_block_backed_filesystems()` — it walks every block-backed entry in `/proc/filesystems` and tries each one. Every one rejects `nolock` as an unknown parameter, so the console fills with errors naming local filesystems that were never involved:

```
ext3: Unknown parameter 'nolock'
ext2: Unknown parameter 'nolock'
ext4: Unknown parameter 'nolock'
vfat: Unknown parameter 'nolock'
msdos: Unknown parameter 'nolock'
f2fs: Unknown parameter 'nolock'
```

That is what a Raspberry Pi 4 reporter saw in [forums topic 18229](https://forums.fogproject.org/topic/18229), and it pointed the diagnosis at the mount options for a day. The real fault was upstream of the mount entirely. With `-t nfs` present, `mp->mnt_type` is set, the walk is skipped, and a bad `storage=` yields one NFS error naming the actual source.

## Behavior change

None where `storage=` is already well formed — busybox was selecting `nfs` there anyway. FOS mounts nothing else with these options, and its scripts never mount CIFS, so the explicit type is safe at all five sites.

## Sites

| file | mount |
|---|---|
| `bin/fog` | `$storage` → `/imagesinit` (post-init scripts) |
| `bin/fog.mount` | `$storage` → `/images`, up and down branches |
| `bin/fog.photorec` | `$storage` → `/images` |
| `bin/fog.av` | `$clamav` → `/opt/fog/clamav` |

## Test

`tests/checks/nfs-mount-type.sh`. It anchors the whole mount line rather than the flag alone, so a rewritten call site fails visibly, and it fails outright if no `nolock` mount is found at all.

Proven to fail before being trusted:

- drop `-t nfs` from one site → red, naming that site
- drop it from two → red, naming both
- move the mount lines entirely → red via the zero-sites guard
- restore → green

Full suite green: 13 checks + golden.