### PR TITLE
Say why the database update failed instead of printing nothing

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.imgcomplete
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.imgcomplete
@@ -19,24 +19,28 @@ count=0
 res=""
 dots "Updating Database"
 while [[ $res != "##" ]]; do
-    res=$(curl -Lks --data "$poststring" ${web}service/$php_post 2>/dev/null)
-    if [[ $res != "##" && $count -lt 10 ]]; then
-        echo "Failed"
-        debugPause
-        printf " * Error returned: %s" "$res"
-        echo
-        debugPause
-        dots "Reattempting to update database"
-    fi
+    # Called directly, NOT in $( ), because it sets serverBody/serverReason and
+    # a subshell would discard both. This used to print $res as the error, so an
+    # empty reply was reported as an empty error and there was nothing to
+    # diagnose from here -- see fogproject GH-1380.
+    postToServer "${web}service/$php_post" "$poststring"
+    res="$serverBody"
+    [[ $res == "##" ]] && break
+    echo "Failed"
+    debugPause
+    printf " * Error returned: %s" "${serverReason:-$res}"
+    echo
+    debugPause
     if [[ $count -ge 10 ]]; then
-        echo "Failed"
-        debugPause
-        printf " * Error returned: %s" "$res"
-        echo
-        debugPause
         handleError "Could not complete tasking ($0)\n   Args Passed: $*"
     fi
     let count+=1
+    # Backing off matches fog.nonimgcomplete, which has always slept between
+    # attempts. Without it this retried eleven times as fast as the server could
+    # fail, which during GH-1380 meant eleven memory-exhaustion fatals back to
+    # back against a server that needed a moment more than it was given.
+    usleep 5000000
+    dots "Reattempting to update database"
 done
 echo "Done"
 debugPause

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.nonimgcomplete
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.nonimgcomplete
@@ -7,15 +7,25 @@ sysuuid=$(dmidecode -s system-uuid)
 sysuuid=${sysuuid,,}
 dots "Updating Database"
 while [[ $res != "##" ]]; do
-    res=$(curl -Lks --data "sysuuid=${sysuuid}&mac=$mactosend" ${web}service/Post_Wipe.php 2>/dev/null)
+    # Called directly, NOT in $( ), because it sets serverBody/serverReason and
+    # a subshell would discard both. This reported nothing at all on failure --
+    # not even the empty "Error returned:" its sibling managed -- so eleven
+    # attempts could go by with no clue why. Same reporting as fog.imgcomplete
+    # now; see fogproject GH-1380.
+    postToServer "${web}service/Post_Wipe.php" "sysuuid=${sysuuid}&mac=$mactosend"
+    res="$serverBody"
     [[ $res == "##" ]] && break
+    echo "Failed"
+    debugPause
+    printf " * Error returned: %s" "${serverReason:-$res}"
+    echo
+    debugPause
     if [[ $count -ge 10 ]]; then
-        echo "Failed"
-        debugPause
         handleError "Could not complete tasking. ($0)\n   Args Passed: $*"
     fi
     let count+=1
     usleep 5000000
+    dots "Reattempting to update database"
 done
 echo "Done"
 debugPause

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -1653,6 +1653,69 @@ reportToServer() {
         "${web}service/taskerror.php" &>/dev/null || :
     return 0
 }
+# POSTs to a FOG service endpoint and says what actually came back.
+#
+# The completion scripts wait for a literal "##" and print whatever they got
+# when it does not arrive. That reported an EMPTY string as the error whenever
+# the server died mid-request, so "Error returned:" was followed by nothing at
+# all and there was nothing to diagnose from the client -- which is exactly how
+# fogproject GH-1380 presented: a capture that had already been renamed into
+# place retried until it gave up, while the server was taking an uncatchable
+# PHP memory-exhaustion fatal on every attempt.
+#
+# Four outcomes have to be told apart, and used to look identical:
+#
+#   curl could not connect       - transport, nothing reached the server
+#   HTTP >= 400                  - it answered, and refused
+#   HTTP 2xx with an empty body  - it accepted and returned nothing, which for
+#                                  PHP means a fatal error, and the reason is in
+#                                  the web server's PHP error log, NOT here
+#   HTTP 2xx with a body         - a real message; print it
+#
+# Sets three variables and returns 0 only when the exchange produced a body:
+#
+#   serverBody    - the response body, empty if there was none
+#   serverStatus  - the HTTP status, 000 when curl never connected
+#   serverReason  - a human-readable description of what went wrong, empty on
+#                   success
+#
+# It sets variables rather than echoing them because a caller needs BOTH the
+# body and the description, and `x=$(postToServer ...)` runs in a subshell where
+# any variable it set is discarded. Call it directly and read the three.
+#
+# -w appends the status on its own line so an empty body stays distinguishable
+# from a failed request; the body is everything before that last newline, so
+# multi-line replies survive intact.
+#
+# $1 is the URL to post to
+# $2 is the already-encoded post data
+postToServer() {
+    local url="$1"
+    local data="$2"
+    local raw=""
+    local rc=0
+    [[ -z $url ]] && handleError "No url passed (${FUNCNAME[0]})\n   Args Passed: $*"
+    serverBody=""
+    serverStatus="000"
+    serverReason=""
+    raw=$(curl -Lks -w $'\n%{http_code}' --data "$data" "$url" 2>/dev/null)
+    rc=$?
+    if [[ $rc -ne 0 ]]; then
+        serverReason="could not reach $url (curl exit $rc)"
+        return 1
+    fi
+    serverStatus="${raw##*$'\n'}"
+    serverBody="${raw%$'\n'*}"
+    if [[ $serverStatus -ge 400 || $serverStatus -eq 0 ]]; then
+        serverReason="HTTP $serverStatus from $url"
+        return 1
+    fi
+    if [[ -z ${serverBody//[[:space:]]/} ]]; then
+        serverReason="HTTP $serverStatus from $url with an EMPTY body -- the server accepted the request and answered with nothing. That is what a PHP fatal error looks like from here; the reason is in the web server's PHP error log, not on this screen."
+        return 1
+    fi
+    return 0
+}
 # Prints an error with visible information
 #
 # $1 is the string to inform what went wrong

--- a/tests/README.md
+++ b/tests/README.md
@@ -75,6 +75,20 @@ tests/checks/error-report.sh  # the failure report handleError() sends to
                               # console, a failed report still lets handleError
                               # reach its reboot notice, and no $web means no
                               # attempt at all
+tests/checks/server-post-reporting.sh
+                              # postToServer() and the two completion scripts
+                              # (fogproject#1380): a connect failure, an HTTP
+                              # >= 400, a 2xx with an EMPTY body and a real
+                              # answer are told apart rather than all printing
+                              # as one blank "Error returned:", an empty 200
+                              # points at the PHP error log because a PHP fatal
+                              # is not catchable server-side, a multi-line body
+                              # survives the -w status split, and -- the case
+                              # that matters -- the caller can still read
+                              # serverReason after the call, since $(postToServer
+                              # ...) runs in a subshell that discards it. Both
+                              # call sites are anchored whole-line for the same
+                              # reason
 tests/checks/wipe.sh          # wipeDisk() issues the right erase primitive per
                               # device class (NVMe/SSD/HDD) and mode
                               # (fast/normal/full), never issues an `nvme format`

--- a/tests/checks/server-post-reporting.sh
+++ b/tests/checks/server-post-reporting.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+#
+# Assertion harness for postToServer() and the two completion scripts that use
+# it.
+#
+#   tests/checks/server-post-reporting.sh   # run all cases, non-zero on failure
+#
+# fog.imgcomplete waits for a literal "##" and printed whatever it got when that
+# did not arrive. When the server died mid-request the body was EMPTY, so the
+# client printed
+#
+#   * Error returned:
+#
+# with nothing after it, eleven times, and there was nothing to diagnose from
+# the machine in front of you. That is exactly how fogproject GH-1380 presented:
+# a capture that had already been renamed into place never reached Complete,
+# while the server was taking an uncatchable PHP memory-exhaustion fatal on every
+# attempt. A PHP fatal is not catchable, so no server-side handler could turn it
+# into a message -- the client is the only place that gap can be closed.
+#
+# fog.nonimgcomplete was worse: it printed no error text at all, ever.
+#
+# postToServer() tells four outcomes apart that used to look identical:
+#
+#   curl could not connect       - transport, nothing reached the server
+#   HTTP >= 400                  - it answered, and refused
+#   HTTP 2xx with an empty body  - it accepted and returned nothing, which for
+#                                  PHP means a fatal, and the reason is in the
+#                                  web server's PHP error log, NOT on screen
+#   HTTP 2xx with a body         - a real message
+#
+# The trap this harness exists to hold shut is the one that was WRITTEN and
+# caught here during development: postToServer sets variables rather than
+# echoing them, because a caller needs both the body and the description, and
+# `x=$(postToServer ...)` runs in a SUBSHELL where every variable it set is
+# discarded. That version looked correct, passed a read-through, and would have
+# reported an empty reason for every failure -- reintroducing the exact bug it
+# was written to fix. Case 6 drives it, and cases 7-8 pin both call sites.
+#
+# Mechanism mirrors tests/checks/error-report.sh: source a sandbox copy of the
+# library with its hardcoded /usr/share/fog/lib path rewritten, and PATH-shadow
+# curl with a stub that emulates -w '\n%{http_code}' from the environment.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_LIB="$HERE/../../Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib"
+REPO_BIN="$HERE/../../Buildroot/board/FOG/FOS/rootfs_overlay/bin"
+
+[[ -f $REPO_LIB/funcs.sh ]] || { echo "ERROR: cannot find funcs.sh under $REPO_LIB" >&2; exit 2; }
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+cp "$REPO_LIB/partition-funcs.sh" "$SANDBOX/partition-funcs.sh"
+sed -e "s#^\. /usr/share/fog/lib/partition-funcs\.sh#. $SANDBOX/partition-funcs.sh#" \
+    "$REPO_LIB/funcs.sh" > "$SANDBOX/funcs.sh"
+
+STUBBIN="$SANDBOX/bin"
+mkdir -p "$STUBBIN"
+
+# curl double. Emulates exactly the one thing postToServer depends on: with
+# -w '\n%{http_code}' the status arrives on its own trailing line after the
+# body. FAKE_BODY may be empty or multi-line; FAKE_CURL_RC drives the transport
+# arm, in which case nothing is written at all, as real curl does on a connect
+# failure.
+cat > "$STUBBIN/curl" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$@" > "$SANDBOX/curl.argv"
+[[ ${FAKE_CURL_RC:-0} -ne 0 ]] && exit "$FAKE_CURL_RC"
+printf '%s' "${FAKE_BODY-}"
+printf '\n%s' "${FAKE_CODE:-200}"
+exit 0
+EOF
+chmod +x "$STUBBIN/curl"
+printf '#!/bin/bash\nexit 0\n' > "$STUBBIN/usleep"
+chmod +x "$STUBBIN/usleep"
+
+PASS=0
+FAIL=0
+note() {
+    if [[ -z $2 ]]; then
+        echo "PASS: $1"; PASS=$((PASS + 1))
+    else
+        echo "FAIL: $1 ($2)"; FAIL=$((FAIL + 1))
+    fi
+}
+
+# Drives postToServer in THIS shell -- not a subshell -- and prints the three
+# variables plus the return code on one line each, so a case can assert on what
+# the caller would actually see.
+drive() {
+    (
+        set +u
+        export PATH="$STUBBIN:$PATH" SANDBOX="$SANDBOX"
+        export FAKE_CURL_RC FAKE_CODE FAKE_BODY
+        . "$SANDBOX/funcs.sh" >/dev/null 2>&1
+        postToServer "http://fog.example/service/Post_Stage2.php" "mac=00:11:22:33:44:55"
+        rc=$?
+        printf 'RC=%s\n' "$rc"
+        printf 'STATUS=%s\n' "$serverStatus"
+        printf 'REASON=%s\n' "$serverReason"
+        printf 'BODY=%s\n' "$serverBody"
+    )
+}
+
+field() { sed -n "s/^$1=//p" <<<"$2" | head -1; }
+
+# --- 1. transport failure -------------------------------------------------
+out=$(FAKE_CURL_RC=7 drive)
+err=""
+[[ $(field RC "$out") == 1 ]] || err="rc=$(field RC "$out")"
+reason=$(field REASON "$out")
+grep -q 'could not reach' <<<"$reason" || err="$err reason=$reason"
+grep -q 'curl exit 7' <<<"$reason" || err="$err no-exit-code"
+note "1. a connect failure names the URL and curl's exit status" "$err"
+
+# --- 2. HTTP error status -------------------------------------------------
+out=$(FAKE_CURL_RC=0 FAKE_CODE=500 FAKE_BODY="Internal Server Error" drive)
+err=""
+[[ $(field RC "$out") == 1 ]] || err="rc=$(field RC "$out")"
+reason=$(field REASON "$out")
+grep -q 'HTTP 500' <<<"$reason" || err="$err reason=$reason"
+note "2. an HTTP >= 400 answer is reported as a status, not as its body" "$err"
+
+# --- 3. the GH-1380 case: 200 with an empty body --------------------------
+out=$(FAKE_CURL_RC=0 FAKE_CODE=200 FAKE_BODY="" drive)
+err=""
+[[ $(field RC "$out") == 1 ]] || err="rc=$(field RC "$out")"
+# Asserted on the REASON field, not on the whole capture: matching anywhere in
+# the output passes when the description is ECHOED rather than assigned, which
+# is the very shape that discards it in a subshell.
+reason=$(field REASON "$out")
+grep -qi 'EMPTY body' <<<"$reason" || err="$err no-empty-mention"
+grep -qi 'PHP error log' <<<"$reason" || err="$err does-not-point-at-the-log"
+[[ -z $(field BODY "$out") ]] || err="$err body=$(field BODY "$out")"
+note "3. an empty 200 says so, and points at the PHP error log" "$err"
+
+# --- 4. the success shape -------------------------------------------------
+out=$(FAKE_CURL_RC=0 FAKE_CODE=200 FAKE_BODY="##" drive)
+err=""
+[[ $(field RC "$out") == 0 ]] || err="rc=$(field RC "$out")"
+[[ $(field BODY "$out") == "##" ]] || err="$err body=$(field BODY "$out")"
+[[ -z $(field REASON "$out") ]] || err="$err reason-set-on-success"
+note "4. a real answer returns 0, with the body intact and no reason" "$err"
+
+# --- 5. a multi-line body survives the status split -----------------------
+out=$(FAKE_CURL_RC=0 FAKE_CODE=200 FAKE_BODY=$'line one\nline two' drive)
+err=""
+grep -q '^BODY=line one$' <<<"$out" || err="first line lost"
+note "5. only the LAST newline is the status separator" "$err"
+
+# --- 6. the variables reach the caller ------------------------------------
+# The bug this whole file exists to hold shut. If postToServer is ever changed
+# back to echoing its description, or a caller wraps it in $( ), serverReason is
+# empty in the caller and the client prints a blank error again.
+out=$(
+    set +u
+    export PATH="$STUBBIN:$PATH" SANDBOX="$SANDBOX" FAKE_CODE=200 FAKE_BODY=""
+    . "$SANDBOX/funcs.sh" >/dev/null 2>&1
+    postToServer "http://fog.example/x.php" "a=b"
+    # Deliberately read AFTER the call returns, in the calling scope.
+    printf 'SEEN=%s\n' "${serverReason:-<empty>}"
+)
+err=""
+[[ $(field SEEN "$out") != "<empty>" ]] || err="caller saw no reason"
+note "6. the caller can read serverReason after the call returns" "$err"
+
+# --- 7/8. both call sites, whole-line anchored ----------------------------
+# Anchored on the whole call line rather than grepping for the function name: a
+# name grep passes when the call has been wrapped in $( ), which is the failure
+# mode being guarded.
+for f in fog.imgcomplete fog.nonimgcomplete; do
+    err=""
+    [[ -f $REPO_BIN/$f ]] || { note "7. $f exists" "missing"; continue; }
+    if grep -Eq '^[[:space:]]*[A-Za-z_]+=\$\(postToServer' "$REPO_BIN/$f"; then
+        err="calls postToServer inside \$( ), which discards its variables"
+    elif ! grep -Eq '^[[:space:]]*postToServer ' "$REPO_BIN/$f"; then
+        err="does not call postToServer directly"
+    elif ! grep -q 'serverReason' "$REPO_BIN/$f"; then
+        err="never prints serverReason, so a failure still says nothing"
+    fi
+    note "7. $f calls postToServer directly and prints its reason" "$err"
+done
+
+echo
+echo "passed: $PASS   failed: $FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
The client half of [fogproject#1380](https://github.com/FOGProject/fogproject/issues/1380). The server-side recursion is fixed there; this is the reason that incident could not be diagnosed from the machine in front of you.

## What happened

`fog.imgcomplete` waits for a literal `##` and printed whatever it got when that did not arrive. When the server dies mid-request the body is **empty**, so the client printed:

```
* Updating Database.............................Failed
* Error returned:
* Reattempting to update database................Failed
* Error returned:
```

Eleven times, with nothing after the colon. A capture that had already been renamed into place never reached Complete, and the actual cause — an uncatchable PHP memory-exhaustion fatal — was only ever visible in the server's PHP error log.

**A PHP fatal cannot be caught**, so no server-side handler can turn it into a message. The client is the only place that gap closes.

`fog.nonimgcomplete` was worse: it printed no error text at all, ever.

## The change

`postToServer()` in `funcs.sh` tells four outcomes apart that used to look identical:

| Outcome | What it says |
|---|---|
| curl could not connect | names the URL and curl's exit status |
| HTTP >= 400 | reports the status, not the error page's body |
| HTTP 2xx, empty body | says it was empty, and points at the **web server's PHP error log** — because that is where the reason for this class of failure lives |
| HTTP 2xx, real body | prints it, as before |

It **sets** `serverBody` / `serverStatus` / `serverReason` rather than echoing them, because a caller needs both the body and the description, and `x=$(postToServer ...)` runs in a subshell where every variable it set is discarded.

That mistake was made and caught during this change. Case 6 of the harness exists to hold it shut, and both call sites are anchored **whole-line** rather than grepped for the function name — a name grep passes when the call has been wrapped in `$( )`, which is precisely the failure mode.

## Also fixed while here

`fog.imgcomplete` had **no backoff** between attempts, unlike `fog.nonimgcomplete`, which has always slept five seconds. It retried eleven times as fast as the server could fail — during #1380 that meant eleven memory-exhaustion fatals back to back against a server that needed a moment more than it was given.

It now sleeps the same five seconds, so the eleven attempts span about a minute rather than milliseconds. **This is a deliberate timing change, not a side effect.**

## Test

`tests/checks/server-post-reporting.sh` — 8 assertions, following the `error-report.sh` sandbox-and-stub pattern (sandbox copy of `funcs.sh` with its hardcoded path rewritten; `curl` PATH-shadowed by a stub that emulates `-w '\n%{http_code}'`).

Cases 1–3 assert on the `serverReason` **field**, not on the whole capture: matching anywhere in the output passes when the description is echoed rather than assigned, which is the shape that discards it in a subshell. That weakness was real — it was caught by running mutation M3 below and tightened.

**Verified by mutation:**

| Mutation | Result |
|---|---|
| revert all three files to pre-fix | all **8** red |
| reintroduce `reason=$(postToServer …)` at one call site | case 7 red **for that file alone** |
| change `postToServer` back to echoing its description | cases 3 and 6 red |

`tests/golden/run.sh check` still reports output byte-identical to the committed fixture.

## Not changed

The `-k` on these curl calls (fos#102) is untouched — that is a separate decision with real consequences for every self-signed install, and it does not belong in a diagnostics fix.

The other ten `curl -Lks` call sites in `rootfs_overlay/bin/` keep their current reporting. Only the two completion scripts are in the #1380 call path; sweeping the rest is worth doing, separately, once this shape has been used in anger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)