### PR TITLE
Run the test suite on every pull request

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+# A pull_request trigger can only fire from the repository the PR is opened
+# against, so this stub has to live here even though every other shared FOG
+# workflow lives in FOGProject/fog-workflows. It is deliberately short: all of
+# the logic is in the reusable workflow, so fixing the runner does not mean
+# editing this file.
+#
+# For pull_request events GitHub reads workflows from the merge of head into
+# base, so one copy on `master` covers every PR opened against it -- the
+# contributor's branch needs nothing.
+#
+# Not a push trigger, and not out of caution: fogproject's equivalent was
+# push-triggered once and the workflow it called pushed a commit back, which
+# re-triggered the stub and put ~30 commits on dev-branch in 20 minutes. This
+# one calls a workflow that writes nothing at all, but the trigger stays a PR
+# trigger so that stays true by construction rather than by review.
+#
+# Added because fos's other four workflows are all release or
+# workflow_dispatch, so until now not one of the fifteen assertion harnesses in
+# tests/ had ever run on a pull request.
+
+on:
+  pull_request:
+
+jobs:
+  suite:
+    # Named because the job KEY is what GitHub puts in the middle of a called
+    # workflow's check name, so an unnamed `suite:` renders every check as
+    # "Tests / suite / tests". `fos` rather than something generic because
+    # fog-workflows hosts fogproject-tests.yml and fog-plugins-tests.yml
+    # alongside this one, and which project's suite is running is the useful
+    # thing for this segment to say.
+    name: fos
+    uses: FOGProject/fog-workflows/.github/workflows/fos-tests.yml@main

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env sh
+#
+# Runs every FOS dev test and reports one line each.
+#
+# The convention these tests already follow -- standalone scripts, exit 0 for
+# pass and non-zero for fail, no framework and no hardware -- was documented in
+# tests/README.md but had no runner, so "the FOS tests pass" meant a human
+# remembering sixteen commands and reading sixteen summaries. It also meant
+# there was nothing for CI to call: fos has four workflows and all of them are
+# release or dispatch, so until now not one of these assertions had ever run
+# anywhere but on a maintainer's laptop.
+#
+# Modelled on fogproject's tests/run-all.sh, deliberately: the two projects are
+# maintained by the same people and a suite that reports differently in each is
+# a suite people read less carefully.
+#
+# Usage: sh tests/run-all.sh
+# Exit status 0 = every test passed, 1 = at least one failed.
+
+testdir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+# gawk, not any awk. procsfdisk.awk uses asort() and PROCINFO and funcs.sh uses
+# gensub(), all of which are gawk extensions -- so this is a requirement of the
+# CODE, not of the harness. Measured with `gawk --traditional`, three checks
+# (fill-engine, mbr-extended, resize-engine) fail without them, and they fail as
+# wrong ARITHMETIC rather than as a syntax error: asort() is simply an unknown
+# function whose absence reorders a partition table. That reads as a broken
+# partition engine rather than as a missing package, which is why this refuses
+# up front instead of letting the suite report it.
+#
+# Debian and Ubuntu ship mawk as the default awk, so this fires on a stock
+# runner and on plenty of developer machines.
+# gensub() is the probe rather than asort() or PROCINFO because it is the only
+# one of the three whose absence is a hard error: a missing asort() is an
+# unknown function call, and PROCINFO in a non-gawk awk is just an empty array.
+if ! awk 'BEGIN { exit (gensub(/a/, "b", "g", "aa") == "bb") ? 0 : 1 }' </dev/null 2>/dev/null; then
+    printf 'ERROR: awk on this system is not gawk.\n' >&2
+    printf '       FOS uses asort(), PROCINFO and gensub(), which are gawk\n' >&2
+    printf '       extensions. Install gawk (Debian/Ubuntu: apt install gawk).\n' >&2
+    exit 2
+fi
+
+pass=0
+fail=0
+failed=''
+
+run_one() {
+    name=$1
+    shift
+
+    # Output is captured rather than streamed so a passing test contributes one
+    # line instead of its own hundred; a failing one gets its output replayed in
+    # full below, which is when it is actually wanted.
+    out=$("$@" 2>&1)
+    status=$?
+
+    if [ $status -eq 0 ]; then
+        pass=$((pass + 1))
+        printf 'ok    %s\n' "$name"
+    else
+        fail=$((fail + 1))
+        failed="$failed $name"
+        printf 'FAIL  %s (exit %d)\n' "$name" "$status"
+        printf '%s\n' "$out" | sed 's/^/      /'
+    fi
+}
+
+# bash, not sh. Every check carries a #!/bin/bash shebang and uses bash-only
+# constructs -- [[ ]], arrays, ${BASH_SOURCE[0]}, ${var//pat/rep} -- because the
+# code they exercise (funcs.sh, partition-funcs.sh) is itself bash and cannot be
+# sourced by anything else. Running them with `sh` works only where /bin/sh
+# happens to BE bash; on Debian and Ubuntu it is dash, and there they die on
+# "Bad substitution" before running a single assertion, which reads as a failing
+# suite rather than a mis-invoked one.
+for t in "$testdir"/checks/*.sh; do
+    [ -f "$t" ] || continue
+    run_one "$(basename "$t")" bash "$t"
+done
+
+# The golden harness is a different shape -- one command with a subcommand, and
+# `check` is the only one that asserts anything. `capture` overwrites the
+# fixture, which would make the suite unconditionally green, so it is never what
+# a runner calls.
+if [ -x "$testdir/golden/run.sh" ]; then
+    run_one 'golden/run.sh check' "$testdir/golden/run.sh" check
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+
+if [ $fail -gt 0 ]; then
+    printf 'failed:%s\n' "$failed" >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
`tests/README.md` documents fifteen assertion harnesses and a golden-output differential — several mutation-verified, several written precisely because the bug they catch is invisible from a code read (the partition arithmetic in `fill-engine`/`resize-engine`, the subshell trap in `server-post-reporting`). **None of it had ever run on a pull request.** This repository's four workflows are all release or `workflow_dispatch`, so "the FOS tests pass" meant a maintainer remembering sixteen commands and reading sixteen separate summaries.

## `tests/run-all.sh`

One entry point, modelled on fogproject's runner of the same name so a suite maintained by the same people reports the same way in both.

```
$ sh tests/run-all.sh
ok    arm64-platform-config.sh
ok    error-report.sh
...
ok    golden/run.sh check

16 passed, 0 failed
```

- **`bash`, not `sh`.** The checks use `[[ ]]`, arrays and `${BASH_SOURCE[0]}`, because the code they exercise is itself bash. On Debian/Ubuntu `/bin/sh` is dash, where they die on `Bad substitution` before a single assertion runs — which reads as a failing suite rather than a mis-invoked one.
- **`golden/run.sh check`, never `capture`.** `capture` overwrites the fixture, which would make the suite unconditionally green.
- Passing tests contribute one line; a failing one gets its output replayed in full.

## It refuses unless `awk` is gawk

`procsfdisk.awk` uses `asort()` and `PROCINFO`, `funcs.sh` uses `gensub()` — all gawk extensions — and Debian and Ubuntu ship **mawk** as the default `awk`. Measured with `gawk --traditional`:

```
13 passed, 3 failed
failed: fill-engine.sh mbr-extended.sh resize-engine.sh
```

They fail as wrong partition **arithmetic**, not as a syntax error, because a missing `asort()` is just an unknown function whose absence reorders the table. That reads as a broken partition engine rather than a missing package, so the runner refuses up front with the actual reason.

## The workflow

Six lines. A `pull_request` trigger can only fire from the repository the PR is opened against, so the stub has to live here; everything that might change lives in [FOGProject/fog-workflows#33](https://github.com/FOGProject/fog-workflows/pull/33) (merged), which installs gawk, guards against a checkout that carries no suite, and runs the tee'd step under `shell: bash` so the pipe cannot swallow the exit status.

The called workflow writes nothing — no App token, no commit, no API call — so it has no way to trigger another run of itself.

**This PR self-tests:** GitHub reads `pull_request` workflows from the merge of head into base, so the check on this PR is the workflow being added.