### PR TITLE
Send all four firmware fields with a registration (fogproject #198)

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.auto.reg
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.auto.reg
@@ -65,6 +65,15 @@ sysuuid=$(echo $sysuuid | base64)
 sysserial=$(dmidecode -s system-serial-number)
 sysserial=${sysserial,,}
 sysserial=$(echo $sysserial | base64)
+# The board serial and chassis asset tag join the UUID and system serial
+# so the server can identify this machine by firmware, not only by MAC
+# (fogproject #198). A server that does not know the fields ignores them.
+mbserial=$(dmidecode -s baseboard-serial-number)
+mbserial=${mbserial,,}
+mbserial=$(echo $mbserial | base64)
+caseasset=$(dmidecode -s chassis-asset-tag)
+caseasset=${caseasset,,}
+caseasset=$(echo $caseasset | base64)
 dots "Attempting to register host"
 count=0
 res=""
@@ -73,7 +82,7 @@ if [[ -f /sys/firmware/acpi/tables/MSDM ]]; then
     productKey=$(tail -c+57 /sys/firmware/acpi/tables/MSDM | base64)
 fi
 while [[ -z $res ]]; do
-    callServer "${web}service/auto.register.php" "sysserial=${sysserial}&sysuuid=${sysuuid}&mac=$mac&productKey=${productKey}"
+    callServer "${web}service/auto.register.php" "sysserial=${sysserial}&sysuuid=${sysuuid}&mbserial=${mbserial}&caseasset=${caseasset}&mac=$mac&productKey=${productKey}"
     res="$serverBody"
     case $count in
         [0-8])

--- a/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.man.reg
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/bin/fog.man.reg
@@ -61,7 +61,19 @@ mac=$(getMACAddresses | base64)
 sysuuid=$(dmidecode -s system-uuid)
 sysuuid=${sysuuid,,}
 sysuuid=$(echo $sysuuid | base64)
-callServer "${web}service/man.hostexists.php" "sysuuid=${sysuuid}&mac=$mac"
+sysserial=$(dmidecode -s system-serial-number)
+sysserial=${sysserial,,}
+sysserial=$(echo $sysserial | base64)
+# The board serial and chassis asset tag join the UUID and system serial
+# so the server can identify this machine by firmware, not only by MAC
+# (fogproject #198). A server that does not know the fields ignores them.
+mbserial=$(dmidecode -s baseboard-serial-number)
+mbserial=${mbserial,,}
+mbserial=$(echo $mbserial | base64)
+caseasset=$(dmidecode -s chassis-asset-tag)
+caseasset=${caseasset,,}
+caseasset=$(echo $caseasset | base64)
+callServer "${web}service/man.hostexists.php" "sysuuid=${sysuuid}&sysserial=${sysserial}&mbserial=${mbserial}&caseasset=${caseasset}&mac=$mac"
 exists="$serverBody"
 checkAndSet() {
     local testvar="$1"
@@ -382,7 +394,7 @@ res=""
 # two seconds when the server was unreachable, so the operator watched a blank
 # console with no idea anything was wrong.
 while [[ -z $res ]]; do
-    callServer "${web}service/auto.register.php" "sysuuid=${sysuuid}&mac=$mac&advanced=$(echo -n 1 | base64)&host=$host&imageid=$imageid&primaryuser=$primaryuser&other1=$other1&other2=$other2&doimage=$realdoimage&doad=$blDoAD&location=$location64&ou=$ou64&username=$user64&password=$pass64&groupid=$group64&snapinid=$snapin64&productKey=$productKey"
+    callServer "${web}service/auto.register.php" "sysuuid=${sysuuid}&sysserial=${sysserial}&mbserial=${mbserial}&caseasset=${caseasset}&mac=$mac&advanced=$(echo -n 1 | base64)&host=$host&imageid=$imageid&primaryuser=$primaryuser&other1=$other1&other2=$other2&doimage=$realdoimage&doad=$blDoAD&location=$location64&ou=$ou64&username=$user64&password=$pass64&groupid=$group64&snapinid=$snapin64&productKey=$productKey"
     res="$serverBody"
     echo "${serverReason:-$res}"
     usleep 2000000


### PR DESCRIPTION
Companion to FOGProject/fogproject#1674.

Both registration scripts sent `sysuuid`, and `fog.auto.reg` also `sysserial`. FOG 1.6 identifies a machine by four SMBIOS fields and its registration path now scores whatever arrives, so this sends all four on `auto.register.php` and on the manual path's `man.hostexists.php` check (the manual flow stops at that check, so the attach has to be possible there).

Read, lowercased and base64-encoded exactly as `sysuuid` already is. `doInventory()` overwrites every one of these variables from dmidecode afterward, so the inventory POST is unaffected. A server without the fields ignores them; the 1.6 server side accepts their absence, so the two can merge in either order.

Test suite: 18 passed, 0 failed, golden unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVm9aM4BHJywMoh1eaJMpZ