### PR TITLE
Capture an NTFS partition unresized when ntfsresize cannot adjust its bad sector list

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -632,6 +632,18 @@ shrinkPartition() {
                 tmpoutput=$(cat /tmp/tmpoutput.txt | tr -d \\0)
                 test_string=$(cat /tmp/tmpoutput.txt | egrep -io "(ended successfully|bigger than the device size|volume size is already OK)" | tr -d '[[:space:]]' | tr -d \\0)
                 [[ $ntfsstatus -eq 0 || -n $test_string ]] && break
+                # ntfsresize shrinks $BadClus:$Bad, the sparse file that spans
+                # the whole volume, as part of every resize, and on some
+                # Windows 11 volumes (fogproject issue #762) that truncate
+                # fails while chkdsk finds nothing wrong. The real resize
+                # would fail the same way, so treat the partition as one that
+                # cannot shrink and capture it at its present size, which is
+                # the "not resizable" image type applied to one partition
+                # instead of the whole image.
+                if grep -q "Could not adjust the bad sector list" /tmp/tmpoutput.txt; then
+                    test_string="badclust"
+                    break
+                fi
                 # ntfsresize relocates every cluster that lies past the new end
                 # into the space before it, and on a Windows 11 volume the file
                 # holding those relocations can run out of runlist room before
@@ -663,6 +675,11 @@ shrinkPartition() {
                     echo " * Resize test was successful"
                     do_resizefs=1
                     do_resizepart=1
+                    ntfsstatus=0
+                    ;;
+                badclust)
+                    echo " * Not resizing filesystem $part (ntfsresize cannot adjust its bad sector list; capturing at present size)"
+                    echo "$(cat ${imagePath}/d1.fixed_size_partitions | tr -d \\0):${part_number}" > "$imagePath/d1.fixed_size_partitions"
                     ntfsstatus=0
                     ;;
                 biggerthanthedevicesize|outofroom)

--- a/tests/checks/ntfs-shrink-retry.sh
+++ b/tests/checks/ntfs-shrink-retry.sh
@@ -26,6 +26,11 @@
 #      ntfsresize is never asked for a target at or past the volume size.
 #   4. A dry run that passes first time takes the original target, so the
 #      unaffected majority of captures sees no change.
+#   5. A dry run that fails at "Could not adjust the bad sector list"
+#      (fogproject issue #762) records the partition as fixed size and
+#      captures it unresized, with no retry and no abort. The real resize
+#      would fail the same way, and capturing at present size is the manual
+#      workaround (the "not resizable" image type) applied to one partition.
 #
 # Mechanism mirrors tests/checks/sector-size.sh: source a sandbox copy of the
 # library, PATH-shadow ntfsresize with a double that records every size it was
@@ -75,6 +80,12 @@ case "$mode" in
         bytes=$(( kib * 1024 ))
         echo "$mode $bytes" >> "$SANDBOX/calls"
         [[ $mode == -fs ]] && exit 0
+        if [[ -n $FAKE_BADCLUST ]]; then
+            echo "Relocating needed data ..."
+            echo "Updating \$BadClust file ..."
+            echo "ERROR: Could not adjust the bad sector list"
+            exit 1
+        fi
         if [[ -n $FAKE_OTHER_ERROR ]]; then
             echo "ERROR: Cluster accounting failed at 12345 (0x3039): missing cluster in \$Bitmap"
             exit 1
@@ -99,7 +110,8 @@ FAIL=0
 pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "FAIL: $1"; [[ -n $2 ]] && echo "      $2"; FAIL=$((FAIL + 1)); }
 
-# run_shrink <fits_bytes> [other_error] -- drive shrinkPartition over /dev/sda3.
+# run_shrink <fits_bytes> [other_error] [badclust] -- drive shrinkPartition
+# over /dev/sda3.
 # Leaves the console output in $OUT, the ntfsresize call log in $CALLS, the
 # bytes handed to resizePartition in $RESIZED and the fixed-size file in $FIXED.
 run_shrink() {
@@ -111,7 +123,7 @@ run_shrink() {
         set +u
         export PATH="$STUBBIN:$PATH" SANDBOX="$SANDBOX"
         export VOLUME_BYTES="$VOLUME_BYTES" MIN_BYTES="$MIN_BYTES"
-        export FAKE_FITS_BYTES="$1" FAKE_OTHER_ERROR="$2"
+        export FAKE_FITS_BYTES="$1" FAKE_OTHER_ERROR="$2" FAKE_BADCLUST="$3"
         . "$SANDBOX/funcs.sh"
         handleError() { echo "ABORT: $*"; exit 1; }
         debugPause() { :; }
@@ -194,6 +206,18 @@ if [[ $OUT != *ABORT* && $n -eq 1 && $first -eq $(( WANT_KIB * 1024 )) && $(real
     pass "fits first time: one dry run and one resize at ${WANT_KIB}k"
 else
     fail "fits first time" "tries=$n first=$first want=$(( WANT_KIB * 1024 )) real=$(realruns | tr '\n' ' ')
+$OUT"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. The $BadClus truncate fails: fixed size, one dry run, no resize, no abort.
+run_shrink 0 "" yes
+n=$(dryruns | wc -l)
+if [[ $OUT != *ABORT* && $OUT == *RETURNED* && $OUT == *"bad sector list"* \
+      && $FIXED == *:3* && $n -eq 1 && -z $(realruns) && -z $RESIZED ]]; then
+    pass "bad sector list failure: recorded fixed size after one dry run, no resize"
+else
+    fail "bad sector list fallback" "tries=$n fixed='$FIXED' real='$(realruns | tr '\n' ' ')' resized='$RESIZED'
 $OUT"
 fi
 


### PR DESCRIPTION
For FOGProject/fogproject#762.

ntfsresize shrinks `$BadClus:$Bad` as part of every resize, and on some Windows 11 volumes that truncate fails with `Could not adjust the bad sector list` while chkdsk finds nothing wrong. The dry run failed there and the whole capture aborted. That code path is unchanged upstream since the 2022.10.3 release FOS ships, so a package bump would not change it, and no local volume reproduces it.

The real resize would fail the same way, so when the dry run ends with that message the partition is recorded as fixed size and captured at its present size. That is the "not resizable" image type, the workaround people were already using, applied to the one partition instead of the whole image.

Behavior change worth noting: a capture that used to abort now succeeds with a console line saying the partition was not shrunk, so that image cannot deploy to a smaller disk.

- `tests/checks/ntfs-shrink-retry.sh` gains a fifth case; it fails against the old library and passes with the change.
- Full suite: 20 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131h4axUaE3VJZphvKRdDby