### PR TITLE
Add smallsize=1 to pick the smallest disk, the counterpart of largesize=1

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -1532,12 +1532,18 @@ getHardDisk() {
             fi
         fi
     else
-        if [[ -n $largesize ]]; then
-            # Auto-select largest available drive
+        if [[ -n $largesize || -n $smallsize ]]; then
+            # Kernel arguments largesize=1 / smallsize=1 pick the largest or
+            # the smallest disk by capacity, for fleets where the target disk
+            # sits at a different bus position on every machine but is
+            # always the biggest or (fogproject #817) the smallest one.
+            # Ties keep enumeration order.
+            local order="-k1,1nr"
+            [[ -n $smallsize ]] && order="-k1,1n"
             hd=$(
                 for d in $devs; do
                     echo "$(blockdev --getsize64 "$d") $d"
-                done | sort -k1,1nr -k2,2 | head -1 | cut -d' ' -f2
+                done | sort $order -k2,2 | head -1 | cut -d' ' -f2
             )
         else
             for d in $devs; do

--- a/tests/checks/primary-disk-dedup.sh
+++ b/tests/checks/primary-disk-dedup.sh
@@ -21,10 +21,15 @@
 #      their enumeration order, still once each.
 #   3. A comma-separated fdrive naming two disks yields them in the order
 #      given, with the remainder after.
+#   4. With no fdrive, the kernel arguments largesize=1 and smallsize=1 pick
+#      the largest and the smallest disk by capacity (fogproject #817), and
+#      neither picks the first enumerated.
 #
 # Mechanism mirrors tests/checks/ntfs-shrink-retry.sh: source a sandbox copy
 # of the library and PATH-shadow lsblk, blockdev and blkid with doubles that
-# describe a fixed three-disk machine.
+# describe a fixed three-disk machine whose first-enumerated disk is neither
+# the largest nor the smallest, so each automatic choice lands on a
+# different device.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_LIB="$HERE/../../Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib"
@@ -48,7 +53,7 @@ cat > "$STUBBIN/lsblk" <<'STUB'
 #!/bin/bash
 case "$*" in
     *KNAME,SIZE*)
-        printf '/dev/sda 500G\n/dev/sdb 1T\n/dev/nvme0n1 2T\n'
+        printf '/dev/sda 1T\n/dev/sdb 500G\n/dev/nvme0n1 2T\n'
         ;;
     *SERIAL,WWN*)
         printf 'SERIAL="" WWN=""\n'
@@ -58,8 +63,8 @@ STUB
 cat > "$STUBBIN/blockdev" <<'STUB'
 #!/bin/bash
 case "$2" in
-    /dev/sda) echo 500107862016 ;;
-    /dev/sdb) echo 1000204886016 ;;
+    /dev/sda) echo 1000204886016 ;;
+    /dev/sdb) echo 500107862016 ;;
     *)        echo 2000398934016 ;;
 esac
 STUB
@@ -93,6 +98,24 @@ check() {
 check "first-enumerated disk named once"   "/dev/sda"          "/dev/sda /dev/sdb /dev/nvme0n1"
 check "later disk moves to the front"      "/dev/sdb"          "/dev/sdb /dev/sda /dev/nvme0n1"
 check "two specs keep their given order"   "/dev/nvme0n1,/dev/sda" "/dev/nvme0n1 /dev/sda /dev/sdb"
+
+# Automatic choice: single-disk image, no Host Primary Disk.
+auto() {
+    local name="$1" want="$2"
+    fdrive=""; imgType="n"; type="up"
+    largesize="$3"; smallsize="$4"
+    hd=""; disks=""
+    getHardDisk 2>/dev/null
+    if [[ "$hd" == "$want" && "$disks" == "$want" ]]; then
+        echo "ok    $name"
+    else
+        echo "FAIL  $name: largesize='$3' smallsize='$4' gave hd='$hd' disks='$disks', wanted '$want'"
+        fail=1
+    fi
+}
+auto "no argument takes the first enumerated" "/dev/sda"     "" ""
+auto "largesize=1 takes the largest"          "/dev/nvme0n1" "1" ""
+auto "smallsize=1 takes the smallest"         "/dev/sdb"     "" "1"
 
 [[ $fail -eq 0 ]] && echo "PASS" || echo "FAIL"
 exit $fail


### PR DESCRIPTION
For FOGProject/fogproject#817: with several disks at different bus positions per machine, how do you always deploy to the smallest one?

`getHardDisk()` already honors a `largesize=1` kernel argument that picks the largest disk by capacity when no Host Primary Disk is set. This adds `smallsize=1`, which sorts the same list the other way. Ties keep enumeration order, as before. Both go in Host Kernel Arguments, or on a group.

- `tests/checks/primary-disk-dedup.sh` gains the three automatic choices (none, largest, smallest) on a stub machine whose first disk is neither the largest nor the smallest, so each case lands on a different device. The smallest case fails on the old code.
- Full suite: 20 passed.

Docs for both arguments to follow in fog-docs, since neither is documented today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131h4axUaE3VJZphvKRdDby