### PR TITLE
Never pick a USB or removable device automatically while an internal disk exists

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -1423,6 +1423,26 @@ getHardDisk() {
     local devs
     devs=$(lsblk -dpno KNAME,SIZE -I 3,8,9,179,202,253,259 | awk '$2 != "0B" && !seen[$1]++ { print $1 }')
 
+    # USB and removable devices go to the back of the pool, and the automatic
+    # choice below only considers them when nothing else is present. A USB
+    # audio interface that exposes its driver files as a tiny disk enumerated
+    # as /dev/sda ahead of the NVMe and was deployed to (fogproject #778).
+    # Host Primary Disk still matches them by name, so a deliberate USB
+    # target keeps working, and a machine whose only disk is USB or an SD
+    # card still images.
+    local internal="" removable="" kv d
+    for d in $devs; do
+        kv=$(lsblk -dPno TRAN,RM "$d" 2>/dev/null)
+        if [[ $kv == *'TRAN="usb"'* || $kv == *'RM="1"'* ]]; then
+            removable="$removable$d"$'\n'
+        else
+            internal="$internal$d"$'\n'
+        fi
+    done
+    devs=$(printf '%s%s' "$internal" "$removable")
+    local autodevs="$internal"
+    [[ -z $autodevs ]] && autodevs="$devs"
+
     if [[ -n $fdrive ]]; then
         local found_match=0
         for spec in ${fdrive//,/ }; do
@@ -1541,12 +1561,12 @@ getHardDisk() {
             local order="-k1,1nr"
             [[ -n $smallsize ]] && order="-k1,1n"
             hd=$(
-                for d in $devs; do
+                for d in $autodevs; do
                     echo "$(blockdev --getsize64 "$d") $d"
                 done | sort $order -k2,2 | head -1 | cut -d' ' -f2
             )
         else
-            for d in $devs; do
+            for d in $autodevs; do
                 hd="$d"
                 break
             done

--- a/tests/checks/primary-disk-dedup.sh
+++ b/tests/checks/primary-disk-dedup.sh
@@ -24,12 +24,17 @@
 #   4. With no fdrive, the kernel arguments largesize=1 and smallsize=1 pick
 #      the largest and the smallest disk by capacity (fogproject #817), and
 #      neither picks the first enumerated.
+#   5. A USB or removable device is never the automatic choice while an
+#      internal disk exists (fogproject #778), sits last in the pool, is
+#      still matched by name through fdrive, and is chosen when it is the
+#      only disk.
 #
 # Mechanism mirrors tests/checks/ntfs-shrink-retry.sh: source a sandbox copy
 # of the library and PATH-shadow lsblk, blockdev and blkid with doubles that
-# describe a fixed three-disk machine whose first-enumerated disk is neither
-# the largest nor the smallest, so each automatic choice lands on a
-# different device.
+# describe a fixed machine: a 32 GB USB device enumerated first (the shape of
+# fogproject #778), then three internal disks whose first is neither the
+# largest nor the smallest, so each automatic choice lands on a different
+# device.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_LIB="$HERE/../../Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib"
@@ -53,16 +58,28 @@ cat > "$STUBBIN/lsblk" <<'STUB'
 #!/bin/bash
 case "$*" in
     *KNAME,SIZE*)
-        printf '/dev/sda 1T\n/dev/sdb 500G\n/dev/nvme0n1 2T\n'
+        if [[ -n $FAKE_ONLY_USB ]]; then
+            printf '/dev/sdc 32G\n'
+        else
+            printf '/dev/sdc 32G\n/dev/sda 1T\n/dev/sdb 500G\n/dev/nvme0n1 2T\n'
+        fi
         ;;
     *SERIAL,WWN*)
         printf 'SERIAL="" WWN=""\n'
+        ;;
+    *TRAN,RM*)
+        case "${@: -1}" in
+            /dev/sdc)     printf 'TRAN="usb" RM="0"\n' ;;
+            /dev/nvme0n1) printf 'TRAN="nvme" RM="0"\n' ;;
+            *)            printf 'TRAN="sata" RM="0"\n' ;;
+        esac
         ;;
 esac
 STUB
 cat > "$STUBBIN/blockdev" <<'STUB'
 #!/bin/bash
 case "$2" in
+    /dev/sdc) echo 34359738368 ;;
     /dev/sda) echo 1000204886016 ;;
     /dev/sdb) echo 500107862016 ;;
     *)        echo 2000398934016 ;;
@@ -95,9 +112,10 @@ check() {
     fi
 }
 
-check "first-enumerated disk named once"   "/dev/sda"          "/dev/sda /dev/sdb /dev/nvme0n1"
-check "later disk moves to the front"      "/dev/sdb"          "/dev/sdb /dev/sda /dev/nvme0n1"
-check "two specs keep their given order"   "/dev/nvme0n1,/dev/sda" "/dev/nvme0n1 /dev/sda /dev/sdb"
+check "first-enumerated disk named once"   "/dev/sda"          "/dev/sda /dev/sdb /dev/nvme0n1 /dev/sdc"
+check "later disk moves to the front"      "/dev/sdb"          "/dev/sdb /dev/sda /dev/nvme0n1 /dev/sdc"
+check "two specs keep their given order"   "/dev/nvme0n1,/dev/sda" "/dev/nvme0n1 /dev/sda /dev/sdb /dev/sdc"
+check "a USB device named explicitly"      "/dev/sdc"          "/dev/sdc /dev/sda /dev/sdb /dev/nvme0n1"
 
 # Automatic choice: single-disk image, no Host Primary Disk.
 auto() {
@@ -116,6 +134,7 @@ auto() {
 auto "no argument takes the first enumerated" "/dev/sda"     "" ""
 auto "largesize=1 takes the largest"          "/dev/nvme0n1" "1" ""
 auto "smallsize=1 takes the smallest"         "/dev/sdb"     "" "1"
+FAKE_ONLY_USB=1 auto "a lone USB device is still chosen" "/dev/sdc" "" ""
 
 [[ $fail -eq 0 ]] && echo "PASS" || echo "FAIL"
 exit $fail


### PR DESCRIPTION
For FOGProject/fogproject#778. Stacked on #175, since both change `getHardDisk()` and its harness; it retargets to master when #175 merges.

The reporter's screenshot shows the deploy going to `/dev/sda` on a machine whose OS disk is NVMe, with sgdisk refusing every partition as too big for the disk. That `/dev/sda` is the Focusrite Scarlett's USB storage, which exposes its driver files as a small disk and enumerates ahead of the NVMe.

`getHardDisk()` now puts USB-transport and removable devices (`lsblk TRAN=usb` or `RM=1`) at the back of the pool and leaves them out of the automatic choice, whether that is first-enumerated, `largesize=1` or `smallsize=1`, unless they are the only disks present. Host Primary Disk still matches them by name, so a deliberate USB target keeps working, and a machine whose only disk is USB or an SD card still images.

- `tests/checks/primary-disk-dedup.sh` gains a 32 GB USB device enumerated first and cases for each rule: never chosen automatically, last in the pool, matched by name, chosen when alone. Five of eight cases fail on the old code.
- Full suite: 20 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131h4axUaE3VJZphvKRdDby