### PR TITLE
The stream header width belongs to the record version

### DIFF
--- a/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
+++ b/Buildroot/board/FOG/FOS/rootfs_overlay/usr/share/fog/lib/funcs.sh
@@ -915,13 +915,29 @@ checkStreamIdentity() {
     wanted="$(basename "$wanted")"
     wanted="${wanted%\*}"
     wanted="${wanted%.}"
+    # The width belongs to the record VERSION, not to the reader. A FOGMC1
+    #    record is 128 bytes on both sides, and nothing on the wire tells
+    #    this client otherwise -- so a server that changes the width must
+    #    change the magic with it. An old client then fails the tag test
+    #    below and names the version it cannot read, instead of mis-framing
+    #    the stream. fogproject holds the same pair as
+    #    MulticastTask::STREAM_HEADER_FORMAT and ::STREAM_HEADER_BYTES.
+    local mcHeaderMagic="FOGMC1"
+    local mcHeaderBytes=128
     local hdr=""
-    hdr=$(dd bs=1 count=128 status=none <&9)
+    hdr=$(dd bs=1 count=$mcHeaderBytes status=none <&9)
     local tag="${hdr%% *}"
-    if [[ $tag != FOGMC1 ]]; then
+    if [[ $tag != "$mcHeaderMagic" ]]; then
+        # A stream that carries a record version this client does not read
+        #    is a version skew, and saying which version turns "the deploy
+        #    failed" into "update FOS". Only a well formed magic is echoed;
+        #    an unheadered stream starts with image bytes.
+        if [[ $tag =~ ^FOGMC[0-9]+$ ]]; then
+            handleError "Multicast stream for $wanted carries $tag records and this client reads $mcHeaderMagic; update FOS to match the FOG server (${FUNCNAME[0]})\n   Args Passed: $*"
+        fi
         handleError "Multicast stream for $wanted did not start with a stream header; the server and this client disagree about the stream format (${FUNCNAME[0]})\n   Args Passed: $*"
     fi
-    local got="${hdr#FOGMC1 }"
+    local got="${hdr#"$mcHeaderMagic" }"
     got="${got%%[[:space:]]*}"
     # Quoted: an unquoted right side of [[ != ]] is a PATTERN, so a $wanted
     #    still carrying its glob would match the stem it was supposed to be

--- a/docs/adr/0018-multicast-streams-identify-themselves.md
+++ b/docs/adr/0018-multicast-streams-identify-themselves.md
@@ -109,3 +109,31 @@ by the server it is talking to.
 - **The 128-byte width is duplicated**, as a constant on the server and a
   `dd` count here. Both are pinned by their own repo's checks, but nothing
   compares them across the two.
+
+## Amendments
+
+**2026-09-09 — both gaps above are closed.**
+
+*Prevention.* fogproject #1744 refuses the join instead of catching it
+later. A host whose task has already checked in, to a session that already
+has clients, is turned away in `TaskQueue::checkIn()` — the point
+`fog.checkin` blocks on, before `fog.download` touches the disk. That
+removes the common trigger. The header still covers the rest: a receiver
+that opens late, or a sender chain that moves on for any other reason.
+
+*The duplicated width.* #179 makes the width a property of the record
+version rather than a free number. **A `FOGMC1` record is 128 bytes.** Each
+repo pins that pair, not the number alone, so a width change that keeps the
+magic fails a check on the side that changed. Changing the width therefore
+means bumping the magic, and an old client then meets `FOGMC2`, fails the
+tag test, and names the version it cannot read — instead of mis-framing the
+stream.
+
+`checkStreamIdentity()` names the magic and the width once each, and the
+`dd` counts the named value. The assertion harness reads both out of the
+shipped function and builds every fixture from them, so a fixture can no
+longer agree with a stale belief about the format — which is what the
+restated `printf 'FOGMC1 %-120s\n'` did, and why a server-side change used
+to leave the suite green. Where a fogproject checkout is on the same
+machine, the harness compares the server's constants directly and says when
+it could not.

--- a/tests/checks/multicast-stream-identity.sh
+++ b/tests/checks/multicast-stream-identity.sh
@@ -92,11 +92,40 @@ awk '/^checkStreamIdentity\(\) \{/,/^\}/' "$FUNCS" > "$tmp/fn.sh"
 grep -q 'FOGMC1' "$tmp/fn.sh"
 ck "the function was extracted from the shipped file" "$([[ $? -eq 0 ]] && echo 1 || echo 0)"
 
+# --- the record version owns the width --------------------------------
+
+# Read both out of the shipped function. Everything below builds its
+# fixtures from these, so a fixture cannot agree with a stale belief about
+# the format -- which is what the old restated `printf 'FOGMC1 %-120s\n'`
+# did, and why a server-side width change left this suite green (#179).
+hdr_magic=$(sed -n 's/^[[:space:]]*local mcHeaderMagic="\([^"]*\)".*/\1/p' "$tmp/fn.sh" | head -1)
+hdr_bytes=$(sed -n 's/^[[:space:]]*local mcHeaderBytes=\([0-9][0-9]*\).*/\1/p' "$tmp/fn.sh" | head -1)
+
+ck "the record magic is named in one place" "$([[ -n $hdr_magic ]] && echo 1 || echo 0)"
+ck "the record width is named in one place" "$([[ -n $hdr_bytes ]] && echo 1 || echo 0)"
+
+# The read must use that name. A literal count here would be a second copy
+# of the width inside the very function that owns it.
+grep -q 'dd bs=1 count=\$mcHeaderBytes' "$tmp/fn.sh"
+ck "the header read counts \$mcHeaderBytes, not a literal" "$([[ $? -eq 0 ]] && echo 1 || echo 0)"
+
+# THE CONTRACT. The width is a property of the record version, because
+# nothing on the wire carries it. Changing one without the other lets a
+# server mis-frame an old client silently. If you are here because this
+# failed: bump the magic as well, on both sides, and old clients will
+# refuse by name instead.
+ck "FOGMC1 records are 128 bytes -- change the width, change the magic" \
+    "$([[ $hdr_magic == FOGMC1 && $hdr_bytes -eq 128 ]] && echo 1 || echo 0)"
+
+# 7 bytes of "FOGMC1 " and one newline wrap the padded name.
+hdr_pad=$((hdr_bytes - ${#hdr_magic} - 2))
+hdr_fmt="$hdr_magic %-${hdr_pad}s\n"
+
 # $1 = name the server put in the header, $2 = what the client asks for,
 # $3 = expected outcome (accept|refuse)
 identity_case() {
     local sent="$1" wanted="$2" expect="$3" rc=0
-    printf 'FOGMC1 %-120s\n' "$sent" > "$tmp/stream"
+    printf "$hdr_fmt" "$sent" > "$tmp/stream"
     printf 'PAYLOAD' >> "$tmp/stream"
     (
         handleError() { exit 42; }
@@ -137,7 +166,7 @@ ck "a stream with no header is refused" "$([[ $rc -eq 42 ]] && echo 1 || echo 0)
 
 # Exactly 128 bytes come off the front: one byte more or less and the
 # payload handed to partclone is corrupt.
-printf 'FOGMC1 %-120s\n' 'd1p1.img' > "$tmp/stream"
+printf "$hdr_fmt" 'd1p1.img' > "$tmp/stream"
 printf 'PAYLOADSTARTSHERE' >> "$tmp/stream"
 rest=$(
     handleError() { exit 42; }
@@ -146,7 +175,72 @@ rest=$(
     checkStreamIdentity 'd1p1.img' >/dev/null 2>&1
     cat <&9
 )
-ck "the header consumes exactly 128 bytes" "$([[ $rest == PAYLOADSTARTSHERE ]] && echo 1 || echo 0)"
+ck "the header consumes exactly $hdr_bytes bytes" "$([[ $rest == PAYLOADSTARTSHERE ]] && echo 1 || echo 0)"
+
+# --- a record version this client cannot read --------------------------
+
+# This is what makes bumping the magic a SAFE way to change the width: an
+# old client meets the new version, refuses, and names it. Without this the
+# only alternative to the pair above is a silent mis-frame.
+hdr_next="FOGMC$(( ${hdr_magic#FOGMC} + 1 ))"
+printf "$hdr_next %-${hdr_pad}s\n" 'd1p1.img' > "$tmp/stream"
+printf 'PAYLOAD' >> "$tmp/stream"
+rc=0
+msg=$(
+    handleError() { printf '%s\n' "$1"; exit 42; }
+    . "$tmp/fn.sh"
+    exec 9<"$tmp/stream"
+    checkStreamIdentity 'd1p1.img'
+) || rc=$?
+ck "a $hdr_next record is refused by a $hdr_magic client" "$([[ $rc -eq 42 ]] && echo 1 || echo 0)"
+ck "and the refusal names the version it met" "$([[ $msg == *$hdr_next* ]] && echo 1 || echo 0)"
+
+# An unheadered stream must NOT be reported as a version skew -- it starts
+# with image bytes, and echoing those would print binary to the console.
+printf 'partclone-image and then some binary rubbish' > "$tmp/stream"
+msg=$(
+    handleError() { printf '%s\n' "$1"; exit 42; }
+    . "$tmp/fn.sh"
+    exec 9<"$tmp/stream"
+    checkStreamIdentity 'd1p1.img'
+) || true
+ck "an unheadered stream is not reported as a version skew" \
+    "$([[ $msg != *"carries"* ]] && echo 1 || echo 0)"
+
+# --- the server side, when a checkout is reachable ---------------------
+
+# fogproject writes the header this file reads. Compare the two directly
+# when both trees are on the machine. The pair check above is what CI
+# enforces -- a width change that keeps the magic fails on whichever side
+# changed -- so this is the extra confirmation, not the gate. It SAYS when
+# it did not run: a cross-repo check that skips in silence is the gap #179
+# closes.
+fogtree=""
+for cand in "${FOGPROJECT_TREE:-}" "$HERE/../../../fogproject" "$HOME/fogproject"; do
+    if [[ -n $cand && -r "$cand/packages/web/src/Service/MulticastTask.php" ]]; then
+        fogtree="$cand"
+        break
+    fi
+done
+if [[ -n $fogtree ]]; then
+    mctask="$fogtree/packages/web/src/Service/MulticastTask.php"
+    srv_fmt=$(sed -n "s/^[[:space:]]*const STREAM_HEADER_FORMAT = '\(.*\)';$/\1/p" "$mctask" | head -1)
+    srv_bytes=$(sed -n 's/^[[:space:]]*const STREAM_HEADER_BYTES = \([0-9][0-9]*\);$/\1/p' "$mctask" | head -1)
+    ck "the server's header constants were read from $fogtree" \
+        "$([[ -n $srv_fmt && -n $srv_bytes ]] && echo 1 || echo 0)"
+    ck "the server writes $hdr_magic records" \
+        "$([[ $srv_fmt == "$hdr_magic "* ]] && echo 1 || echo 0)"
+    ck "the server's width matches the width read here" \
+        "$([[ $srv_bytes -eq $hdr_bytes ]] && echo 1 || echo 0)"
+    # And the server's own format has to expand to the width it declares,
+    # or the constant is right and the bytes on the wire are not.
+    srv_rendered=$(printf "$srv_fmt" 'd1p1.img' | wc -c)
+    ck "the server's format expands to $srv_bytes bytes" \
+        "$([[ $srv_rendered -eq $srv_bytes ]] && echo 1 || echo 0)"
+else
+    echo "note: no fogproject checkout found; the server-side width was not compared"
+    echo "      (set FOGPROJECT_TREE to compare)"
+fi
 
 if [[ $fails -gt 0 ]]; then
     echo "multicast-stream-identity: $fails of $checked checks failed"


### PR DESCRIPTION
Fixes #179. Closes the second known gap in ADR-0018.

### The problem

The identity header is 128 bytes. That number appeared in three places across two repos, and one of them was this repo's own harness:

| Where | What it said |
|---|---|
| fogproject `MulticastTask.php:241` | `const STREAM_HEADER_FORMAT = 'FOGMC1 %-120s\n';` |
| fogproject `MulticastTask.php:248` | `const STREAM_HEADER_BYTES = 128;` |
| `funcs.sh:919` | `dd bs=1 count=128` |
| `tests/checks/multicast-stream-identity.sh:99` | `printf 'FOGMC1 %-120s\n'` |

The last row is the one that mattered. The harness built its fixtures from a restated copy of the server's format string, so it shared the assumption it exists to test. A server-side width change left the whole FOS suite green.

### The fix

Nothing on the wire carries the width, so the two sides cannot negotiate it. Make it a property of the record version instead: **a `FOGMC1` record is 128 bytes, and nothing else.**

- `checkStreamIdentity()` names `mcHeaderMagic` and `mcHeaderBytes` once each, and the `dd` counts the named value.
- The harness pins the **pair**. A width change that keeps the magic fails a check on the side that changed it. That is the enforcement, and it needs no second checkout, so neither repo's CI has to depend on the other.
- Changing the width therefore means bumping the magic. An old client meets `FOGMC2`, fails the tag test, and says which version it met. Only a well-formed `FOGMC<n>` tag is echoed — an unheadered stream starts with image bytes.
- The harness reads the magic and the width out of the shipped function and derives every fixture from them.
- Where a fogproject checkout is on the same machine it compares the server's constants directly, and prints a line when it could not. Set `FOGPROJECT_TREE` to point it somewhere else.

### Verification

`tests/checks/multicast-stream-identity.sh` goes from 17 to 28 checks (24 without a fogproject tree). Mutation-verified — each of these turns it red:

- `mcHeaderBytes=160` with the magic unchanged — 2 checks
- `mcHeaderMagic="FOGMC2"` with the width unchanged — 2 checks
- the `dd` count back to a literal `128` — 1 check
- the version-skew arm removed — 1 check
- **the server's constants widened to 160 with FOS untouched — 1 check.** That is the drift this closes, and it used to pass.

Full FOS suite 21 passed / 0 failed.

### Also in this PR

ADR-0018 gains an Amendments section. Both of its known gaps are now closed: prevention arrived with fogproject #1744, and the duplicated width with this change.

### Considered and not done

Read to the newline rather than counting bytes. The record ends in `\n` and bash `read` consumes a pipe one byte at a time, so it would drop the client's copy of the width entirely. ADR-0018 chose the fixed-width read deliberately, the shipped code is verified on hardware, and the failure mode of the drift is a failed deploy rather than a wrong image. Rewriting the wire read costs more risk than it removes.

The paired server-side change is FOGProject/fogproject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A767exFmz6sQUcuZofqE1V
